### PR TITLE
chore: 스킬별 model 설정 추가로 비용/성능 최적화

### DIFF
--- a/.claude/skills/analyze-codebase/SKILL.md
+++ b/.claude/skills/analyze-codebase/SKILL.md
@@ -2,6 +2,7 @@
 name: analyze-codebase
 description: 코드베이스 구조를 분석하고 요약합니다
 user-invocable: true
+model: sonnet
 context: fork
 agent: Explore
 ---

--- a/.claude/skills/go-convention/SKILL.md
+++ b/.claude/skills/go-convention/SKILL.md
@@ -2,6 +2,7 @@
 name: go-convention
 description: Go 코드를 작성하거나 리뷰할 때 프로젝트의 코딩 컨벤션을 적용합니다. Go 파일을 생성, 수정, 리뷰할 때 자동으로 사용됩니다.
 user-invocable: true
+model: haiku
 allowed-tools: Read, Grep, Glob
 ---
 

--- a/.claude/skills/go-project-layout/SKILL.md
+++ b/.claude/skills/go-project-layout/SKILL.md
@@ -2,6 +2,7 @@
 name: go-project-layout
 description: Go 프로젝트를 새로 생성하거나 구조를 변경할 때 clean architecture 폴더 구조를 적용합니다.
 user-invocable: true
+model: haiku
 allowed-tools: Read, Grep, Glob
 ---
 


### PR DESCRIPTION
## Summary
- analyze-codebase 스킬에 `model: sonnet` 설정 (분석/요약 품질 유지)
- go-convention 스킬에 `model: haiku` 설정 (단순 규칙 참조, 비용 절감)
- go-project-layout 스킬에 `model: haiku` 설정 (템플릿성 작업, 비용 절감)

## Test plan
- [ ] `/analyze-codebase` 실행 시 sonnet 모델로 동작 확인
- [ ] `/go-convention` 실행 시 haiku 모델로 동작 확인
- [ ] `/go-project-layout` 실행 시 haiku 모델로 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)