### PR TITLE
feat: Strategy, Factory 패턴 예제 및 README 추가

### DIFF
--- a/golang/pattern/example_test.go
+++ b/golang/pattern/example_test.go
@@ -1,0 +1,101 @@
+package pattern
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/kenshin579/tutorials-go/golang/pattern/factory"
+	"github.com/kenshin579/tutorials-go/golang/pattern/strategy"
+)
+
+// =============================================================================
+// Strategy Pattern 예제
+// =============================================================================
+
+func TestStrategyPattern(t *testing.T) {
+	ctx := context.Background()
+
+	fmt.Println("========================================")
+	fmt.Println("Strategy Pattern Example")
+	fmt.Println("========================================")
+	fmt.Println()
+
+	// 1. 신용카드 결제 서비스로 시작
+	creditCardService := strategy.NewCreditCardService("1234567890123456", "123")
+	paymentUsecase := strategy.NewPaymentUsecase(creditCardService)
+
+	fmt.Println("--- 신용카드로 결제 ---")
+	result, _ := paymentUsecase.ProcessPayment(ctx, 50000)
+	fmt.Printf("Result: %+v\n\n", result)
+
+	// 2. 런타임에 카카오페이 서비스로 전략 변경
+	kakaoPayService := strategy.NewKakaoPayService("user123")
+	paymentUsecase.SetStrategy(kakaoPayService)
+
+	fmt.Println("--- 카카오페이로 결제 ---")
+	result, _ = paymentUsecase.ProcessPayment(ctx, 30000)
+	fmt.Printf("Result: %+v\n\n", result)
+
+	// 3. 네이버페이 서비스로 전략 변경
+	naverPayService := strategy.NewNaverPayService("user456")
+	paymentUsecase.SetStrategy(naverPayService)
+
+	fmt.Println("--- 네이버페이로 결제 ---")
+	result, _ = paymentUsecase.ProcessPayment(ctx, 25000)
+	fmt.Printf("Result: %+v\n\n", result)
+}
+
+// =============================================================================
+// Factory Pattern (Strategy Provider) 예제
+// =============================================================================
+
+func TestFactoryPattern(t *testing.T) {
+	ctx := context.Background()
+
+	fmt.Println("========================================")
+	fmt.Println("Factory Pattern (Strategy Provider) Example")
+	fmt.Println("========================================")
+	fmt.Println()
+
+	// 1. 각 Service 생성
+	emailService := factory.NewEmailService("smtp.gmail.com", 587)
+	smsService := factory.NewSMSService("api-key-123", "010-1234-5678")
+	pushService := factory.NewPushService("fcm-token-abc")
+	slackService := factory.NewSlackService("https://hooks.slack.com/xxx")
+
+	// 2. UserPreferenceStore 생성 (사용자 설정 저장소)
+	userPrefStore := factory.NewMockUserPreferenceStore()
+
+	// 3. Strategy Provider (Factory) 생성
+	provider := factory.NewNotificationStrategyProvider(
+		emailService,
+		smsService,
+		pushService,
+		slackService,
+		userPrefStore,
+	)
+
+	// 4. NotificationUsecase 생성
+	notificationUsecase := factory.NewNotificationUsecase(provider)
+
+	// 5. 타입을 직접 지정하여 알림 전송
+	fmt.Println("--- 타입 직접 지정 방식 ---")
+	_ = notificationUsecase.SendByType(ctx, factory.NotificationTypeSlack, "#general", "Hello Slack!")
+	fmt.Println()
+
+	// 6. 사용자별 설정에 따라 자동으로 Strategy 선택
+	fmt.Println("--- 사용자 설정 기반 방식 (Factory Pattern 핵심) ---")
+	fmt.Println()
+
+	users := []string{"user001", "user002", "user003", "user004"}
+	for _, userID := range users {
+		fmt.Printf("Sending notification to %s:\n", userID)
+		err := notificationUsecase.SendByUserPreference(ctx, userID, "Your order has been shipped!")
+		if err != nil {
+			fmt.Printf("Error: %v\n", err)
+		}
+		fmt.Println()
+	}
+}
+

--- a/golang/pattern/factory/README.md
+++ b/golang/pattern/factory/README.md
@@ -1,0 +1,171 @@
+# Factory Pattern (팩토리 패턴) - Strategy Provider
+
+## 목적
+
+객체 생성 로직을 캡슐화하여 조건에 따라 적절한 객체를 제공합니다.
+
+## 구조
+
+```mermaid
+classDiagram
+    class NotificationStrategyProvider {
+        <<interface>>
+        +Get(ctx, notificationType) NotificationStrategy, bool
+        +GetByUserPreference(ctx, userID) NotificationStrategy, bool
+    }
+
+    class notificationStrategyProvider {
+        -strategies map~NotificationType, NotificationStrategy~
+        -userPreferenceStore UserPreferenceStore
+        +Get(ctx, notificationType) NotificationStrategy, bool
+        +GetByUserPreference(ctx, userID) NotificationStrategy, bool
+    }
+
+    class NotificationStrategy {
+        <<interface>>
+        +Send(ctx, to, message) error
+        +GetType() NotificationType
+    }
+
+    class EmailService {
+        -smtpHost string
+        -smtpPort int
+        +Send(ctx, to, message) error
+        +GetType() NotificationType
+    }
+
+    class SMSService {
+        -apiKey string
+        +Send(ctx, to, message) error
+        +GetType() NotificationType
+    }
+
+    class PushService {
+        -serverKey string
+        +Send(ctx, to, message) error
+        +GetType() NotificationType
+    }
+
+    class SlackService {
+        -webhookURL string
+        +Send(ctx, to, message) error
+        +GetType() NotificationType
+    }
+
+    NotificationStrategyProvider <|.. notificationStrategyProvider : implements
+    notificationStrategyProvider --> NotificationStrategy : provides
+    NotificationStrategy <|.. EmailService : implements
+    NotificationStrategy <|.. SMSService : implements
+    NotificationStrategy <|.. PushService : implements
+    NotificationStrategy <|.. SlackService : implements
+```
+
+## 파일 구성
+
+| 파일 | 설명 |
+|------|------|
+| `domain.go` | `NotificationStrategy`, `NotificationStrategyProvider` 인터페이스 정의 |
+| `email_service.go` | 이메일 알림 서비스 구현체 |
+| `sms_service.go` | SMS 알림 서비스 구현체 |
+| `push_service.go` | 푸시 알림 서비스 구현체 |
+| `slack_service.go` | Slack 알림 서비스 구현체 |
+| `provider.go` | Strategy Provider (Factory) 구현 |
+| `notification_usecase.go` | 알림 유스케이스 (Context) |
+| `user_preference_store.go` | 사용자 설정 저장소 (Mock) |
+
+## 핵심 구성요소
+
+- **Strategy Interface**: `NotificationStrategy` - 알림 전송 공통 인터페이스
+- **Concrete Strategies**: `EmailService`, `SMSService`, `PushService`, `SlackService` - 구현체
+- **Factory**: `NotificationStrategyProvider` - 조건에 따라 Strategy 제공
+- **Context**: `NotificationUsecase` - Provider를 통해 Strategy를 얻어 사용
+- **Configuration**: `UserPreferenceStore` - 사용자 알림 설정 저장소
+
+## 사용 예제
+
+```go
+// 1. 각 알림 서비스 생성
+emailService := NewEmailService("smtp.example.com", 587)
+smsService := NewSMSService("api-key-xxx")
+pushService := NewPushService("fcm-server-key")
+slackService := NewSlackService("webhook-url")
+
+// 2. Provider 생성 (여러 Service 등록)
+provider := NewNotificationStrategyProvider(
+    emailService,
+    smsService,
+    pushService,
+    slackService,
+    userPreferenceStore,
+)
+
+// 3. Usecase 생성
+notificationUsecase := NewNotificationUsecase(provider)
+
+// 4. 타입으로 직접 알림 전송
+notificationUsecase.Send(ctx, NotificationTypeEmail, "user@example.com", "Hello!")
+
+// 5. 사용자 설정에 따라 자동으로 Strategy 선택
+notificationUsecase.SendByUserPreference(ctx, userID, "Your order has been shipped!")
+```
+
+## 패턴 적용의 장점
+
+### 1. 확장성 (Open/Closed Principle)
+
+새로운 알림 채널(카카오톡, 텔레그램 등)을 추가해도 기존 코드 수정 없이 새 Service만 구현하면 됩니다.
+
+```go
+// 새로운 알림 서비스 추가
+type KakaoTalkService struct {
+    apiKey string
+}
+
+func (s *KakaoTalkService) Send(ctx context.Context, to, message string) error {
+    // 카카오톡 알림 전송 로직
+}
+
+func (s *KakaoTalkService) GetType() NotificationType {
+    return NotificationTypeKakaoTalk
+}
+
+// Provider에 등록
+strategies[NotificationTypeKakaoTalk] = kakaoTalkService
+```
+
+### 2. 유연한 Strategy 선택
+
+조건에 따라 동적으로 적절한 Strategy를 선택할 수 있습니다.
+
+```go
+// 타입으로 직접 선택
+strategy, ok := provider.Get(ctx, NotificationTypeEmail)
+
+// 사용자 설정에 따라 자동 선택
+strategy, ok := provider.GetByUserPreference(ctx, userID)
+```
+
+### 3. 테스트 용이성
+
+각 Service와 Provider를 독립적으로 테스트할 수 있습니다.
+
+```go
+func TestEmailService(t *testing.T) {
+    service := NewEmailService("smtp.test.com", 587)
+    err := service.Send(ctx, "test@example.com", "Test message")
+    assert.NoError(t, err)
+}
+
+func TestProvider(t *testing.T) {
+    provider := NewNotificationStrategyProvider(emailService, ...)
+    strategy, ok := provider.Get(ctx, NotificationTypeEmail)
+    assert.True(t, ok)
+    assert.Equal(t, NotificationTypeEmail, strategy.GetType())
+}
+```
+
+## 테스트 실행
+
+```bash
+go test -v -run TestFactoryPattern ./...
+```

--- a/golang/pattern/factory/domain.go
+++ b/golang/pattern/factory/domain.go
@@ -1,0 +1,29 @@
+package factory
+
+import "context"
+
+// NotificationStrategy는 알림 전송을 위한 전략 인터페이스입니다.
+type NotificationStrategy interface {
+	Send(ctx context.Context, to string, message string) error
+	GetType() NotificationType
+}
+
+type NotificationType string
+
+const (
+	NotificationTypeEmail NotificationType = "email"
+	NotificationTypeSMS   NotificationType = "sms"
+	NotificationTypePush  NotificationType = "push"
+	NotificationTypeSlack NotificationType = "slack"
+)
+
+// NotificationStrategyProvider는 알림 타입에 따라 적절한 Strategy를 제공합니다.
+type NotificationStrategyProvider interface {
+	Get(ctx context.Context, notificationType NotificationType) (NotificationStrategy, bool)
+	GetByUserPreference(ctx context.Context, userID string) (NotificationStrategy, bool)
+}
+
+// UserPreferenceStore는 사용자 알림 설정을 조회하는 인터페이스입니다.
+type UserPreferenceStore interface {
+	GetPreferredNotificationType(ctx context.Context, userID string) (NotificationType, error)
+}

--- a/golang/pattern/factory/email_service.go
+++ b/golang/pattern/factory/email_service.go
@@ -1,0 +1,26 @@
+package factory
+
+import (
+	"context"
+	"fmt"
+)
+
+// EmailService는 이메일 알림 서비스입니다.
+type EmailService struct {
+	smtpHost string
+	smtpPort int
+}
+
+func NewEmailService(host string, port int) *EmailService {
+	return &EmailService{smtpHost: host, smtpPort: port}
+}
+
+func (s *EmailService) Send(ctx context.Context, to string, message string) error {
+	fmt.Printf("[Email] Sending to %s via %s:%d\n", to, s.smtpHost, s.smtpPort)
+	fmt.Printf("[Email] Message: %s\n", message)
+	return nil
+}
+
+func (s *EmailService) GetType() NotificationType {
+	return NotificationTypeEmail
+}

--- a/golang/pattern/factory/notification_usecase.go
+++ b/golang/pattern/factory/notification_usecase.go
@@ -1,0 +1,37 @@
+package factory
+
+import (
+	"context"
+	"fmt"
+)
+
+// NotificationUsecase는 알림 유스케이스입니다.
+// Provider를 통해 적절한 Strategy를 얻어 알림을 전송합니다.
+type NotificationUsecase struct {
+	strategyProvider NotificationStrategyProvider
+}
+
+func NewNotificationUsecase(provider NotificationStrategyProvider) *NotificationUsecase {
+	return &NotificationUsecase{strategyProvider: provider}
+}
+
+// SendByType은 지정된 타입으로 알림을 전송합니다.
+func (u *NotificationUsecase) SendByType(ctx context.Context, notificationType NotificationType, to, message string) error {
+	strategy, ok := u.strategyProvider.Get(ctx, notificationType)
+	if !ok {
+		return fmt.Errorf("notification strategy not found for type: %s", notificationType)
+	}
+
+	return strategy.Send(ctx, to, message)
+}
+
+// SendByUserPreference는 사용자 설정에 따라 알림을 전송합니다.
+func (u *NotificationUsecase) SendByUserPreference(ctx context.Context, userID, message string) error {
+	strategy, ok := u.strategyProvider.GetByUserPreference(ctx, userID)
+	if !ok {
+		return fmt.Errorf("notification strategy not found for user: %s", userID)
+	}
+
+	fmt.Printf("Sending notification with strategy: %s\n", strategy.GetType())
+	return strategy.Send(ctx, userID, message)
+}

--- a/golang/pattern/factory/provider.go
+++ b/golang/pattern/factory/provider.go
@@ -1,0 +1,51 @@
+package factory
+
+import (
+	"context"
+	"fmt"
+)
+
+// notificationStrategyProvider는 NotificationStrategyProvider의 구현체입니다.
+type notificationStrategyProvider struct {
+	strategies          map[NotificationType]NotificationStrategy
+	userPreferenceStore UserPreferenceStore
+}
+
+// NewNotificationStrategyProvider는 Provider를 생성합니다.
+func NewNotificationStrategyProvider(
+	emailService *EmailService,
+	smsService *SMSService,
+	pushService *PushService,
+	slackService *SlackService,
+	userPreferenceStore UserPreferenceStore,
+) NotificationStrategyProvider {
+	strategies := map[NotificationType]NotificationStrategy{
+		NotificationTypeEmail: emailService,
+		NotificationTypeSMS:   smsService,
+		NotificationTypePush:  pushService,
+		NotificationTypeSlack: slackService,
+	}
+
+	return &notificationStrategyProvider{
+		strategies:          strategies,
+		userPreferenceStore: userPreferenceStore,
+	}
+}
+
+// Get은 알림 타입에 해당하는 Strategy를 반환합니다.
+func (p *notificationStrategyProvider) Get(ctx context.Context, notificationType NotificationType) (NotificationStrategy, bool) {
+	strategy, ok := p.strategies[notificationType]
+	return strategy, ok
+}
+
+// GetByUserPreference는 사용자 설정에 따른 Strategy를 반환합니다.
+func (p *notificationStrategyProvider) GetByUserPreference(ctx context.Context, userID string) (NotificationStrategy, bool) {
+	preferredType, err := p.userPreferenceStore.GetPreferredNotificationType(ctx, userID)
+	if err != nil {
+		fmt.Printf("Failed to get user preference: %v\n", err)
+		return nil, false
+	}
+
+	strategy, ok := p.strategies[preferredType]
+	return strategy, ok
+}

--- a/golang/pattern/factory/push_service.go
+++ b/golang/pattern/factory/push_service.go
@@ -1,0 +1,25 @@
+package factory
+
+import (
+	"context"
+	"fmt"
+)
+
+// PushService는 푸시 알림 서비스입니다.
+type PushService struct {
+	fcmToken string
+}
+
+func NewPushService(fcmToken string) *PushService {
+	return &PushService{fcmToken: fcmToken}
+}
+
+func (s *PushService) Send(ctx context.Context, to string, message string) error {
+	fmt.Printf("[Push] Sending to device %s\n", to)
+	fmt.Printf("[Push] Message: %s\n", message)
+	return nil
+}
+
+func (s *PushService) GetType() NotificationType {
+	return NotificationTypePush
+}

--- a/golang/pattern/factory/slack_service.go
+++ b/golang/pattern/factory/slack_service.go
@@ -1,0 +1,25 @@
+package factory
+
+import (
+	"context"
+	"fmt"
+)
+
+// SlackService는 Slack 알림 서비스입니다.
+type SlackService struct {
+	webhookURL string
+}
+
+func NewSlackService(webhookURL string) *SlackService {
+	return &SlackService{webhookURL: webhookURL}
+}
+
+func (s *SlackService) Send(ctx context.Context, to string, message string) error {
+	fmt.Printf("[Slack] Sending to channel %s via webhook\n", to)
+	fmt.Printf("[Slack] Message: %s\n", message)
+	return nil
+}
+
+func (s *SlackService) GetType() NotificationType {
+	return NotificationTypeSlack
+}

--- a/golang/pattern/factory/sms_service.go
+++ b/golang/pattern/factory/sms_service.go
@@ -1,0 +1,26 @@
+package factory
+
+import (
+	"context"
+	"fmt"
+)
+
+// SMSService는 SMS 알림 서비스입니다.
+type SMSService struct {
+	apiKey    string
+	senderNum string
+}
+
+func NewSMSService(apiKey, senderNum string) *SMSService {
+	return &SMSService{apiKey: apiKey, senderNum: senderNum}
+}
+
+func (s *SMSService) Send(ctx context.Context, to string, message string) error {
+	fmt.Printf("[SMS] Sending to %s from %s\n", to, s.senderNum)
+	fmt.Printf("[SMS] Message: %s\n", message)
+	return nil
+}
+
+func (s *SMSService) GetType() NotificationType {
+	return NotificationTypeSMS
+}

--- a/golang/pattern/factory/user_preference_store.go
+++ b/golang/pattern/factory/user_preference_store.go
@@ -1,0 +1,30 @@
+package factory
+
+import (
+	"context"
+	"errors"
+)
+
+// mockUserPreferenceStore는 테스트/데모용 UserPreferenceStore 구현체입니다.
+type mockUserPreferenceStore struct {
+	preferences map[string]NotificationType
+}
+
+func NewMockUserPreferenceStore() UserPreferenceStore {
+	return &mockUserPreferenceStore{
+		preferences: map[string]NotificationType{
+			"user001": NotificationTypeEmail,
+			"user002": NotificationTypeSMS,
+			"user003": NotificationTypePush,
+			"user004": NotificationTypeSlack,
+		},
+	}
+}
+
+func (s *mockUserPreferenceStore) GetPreferredNotificationType(ctx context.Context, userID string) (NotificationType, error) {
+	pref, ok := s.preferences[userID]
+	if !ok {
+		return "", errors.New("user preference not found")
+	}
+	return pref, nil
+}

--- a/golang/pattern/strategy/README.md
+++ b/golang/pattern/strategy/README.md
@@ -1,0 +1,143 @@
+# Strategy Pattern (전략 패턴)
+
+## 목적
+
+알고리즘을 캡슐화하여 런타임에 교체할 수 있게 합니다.
+
+## 구조
+
+```mermaid
+classDiagram
+    class PaymentStrategy {
+        <<interface>>
+        +Pay(ctx, amount) PaymentResult, error
+        +Refund(ctx, transactionID) error
+        +GetName() string
+    }
+
+    class CreditCardService {
+        -cardNumber string
+        -cvv string
+        +Pay(ctx, amount) PaymentResult, error
+        +Refund(ctx, transactionID) error
+        +GetName() string
+    }
+
+    class KakaoPayService {
+        -userID string
+        +Pay(ctx, amount) PaymentResult, error
+        +Refund(ctx, transactionID) error
+        +GetName() string
+    }
+
+    class NaverPayService {
+        -userID string
+        +Pay(ctx, amount) PaymentResult, error
+        +Refund(ctx, transactionID) error
+        +GetName() string
+    }
+
+    class PaymentUsecase {
+        -strategy PaymentStrategy
+        +ProcessPayment(ctx, amount) PaymentResult, error
+        +SetStrategy(strategy)
+    }
+
+    PaymentStrategy <|.. CreditCardService : implements
+    PaymentStrategy <|.. KakaoPayService : implements
+    PaymentStrategy <|.. NaverPayService : implements
+    PaymentUsecase --> PaymentStrategy : uses
+```
+
+## 파일 구성
+
+| 파일 | 설명 |
+|------|------|
+| `domain.go` | `PaymentStrategy` 인터페이스 및 `PaymentResult` 타입 정의 |
+| `credit_card_service.go` | 신용카드 결제 서비스 구현체 |
+| `kakao_pay_service.go` | 카카오페이 결제 서비스 구현체 |
+| `naver_pay_service.go` | 네이버페이 결제 서비스 구현체 |
+| `payment_usecase.go` | 결제 유스케이스 (Context) |
+| `helper.go` | 헬퍼 함수 |
+
+## 핵심 구성요소
+
+- **Strategy Interface**: `PaymentStrategy` - 공통 인터페이스
+- **Concrete Strategies**: `CreditCardService`, `KakaoPayService`, `NaverPayService` - 구현체
+- **Context**: `PaymentUsecase` - Strategy를 사용하는 클라이언트
+
+## 사용 예제
+
+```go
+// 1. Service 생성 (Strategy 구현체)
+creditCardService := NewCreditCardService("1234-5678-9012-3456", "123")
+
+// 2. Usecase에 Strategy 주입
+paymentUsecase := NewPaymentUsecase(creditCardService)
+
+// 3. 결제 처리
+result, err := paymentUsecase.ProcessPayment(ctx, 50000)
+
+// 4. 런타임에 Strategy 교체
+kakaoPayService := NewKakaoPayService("user123")
+paymentUsecase.SetStrategy(kakaoPayService)
+
+// 5. 다른 결제 방식으로 처리
+result, err = paymentUsecase.ProcessPayment(ctx, 30000)
+```
+
+## 패턴 적용의 장점
+
+### 1. 확장성 (Open/Closed Principle)
+
+새로운 결제 방식(토스페이 등)을 추가해도 기존 코드 수정 없이 새 Service만 구현하면 됩니다.
+
+```go
+// 새로운 결제 서비스 추가
+type TossPayService struct {
+    userID string
+}
+
+func (s *TossPayService) Pay(ctx context.Context, amount int) (PaymentResult, error) {
+    // 토스페이 결제 로직
+}
+
+func (s *TossPayService) Refund(ctx context.Context, transactionID string) error {
+    // 환불 로직
+}
+
+func (s *TossPayService) GetName() string {
+    return "TossPay"
+}
+```
+
+### 2. 런타임 교체
+
+조건에 따라 동적으로 알고리즘 변경이 가능합니다.
+
+```go
+if user.IsVIP {
+    paymentUsecase.SetStrategy(premiumPaymentService)
+} else {
+    paymentUsecase.SetStrategy(standardPaymentService)
+}
+```
+
+### 3. 테스트 용이성
+
+각 Service를 독립적으로 테스트할 수 있습니다.
+
+```go
+func TestCreditCardService(t *testing.T) {
+    service := NewCreditCardService("1234-5678-9012-3456", "123")
+    result, err := service.Pay(ctx, 10000)
+    assert.NoError(t, err)
+    assert.Equal(t, "SUCCESS", result.Status)
+}
+```
+
+## 테스트 실행
+
+```bash
+go test -v -run TestStrategyPattern ./...
+```

--- a/golang/pattern/strategy/credit_card_service.go
+++ b/golang/pattern/strategy/credit_card_service.go
@@ -1,0 +1,44 @@
+package strategy
+
+import (
+	"context"
+	"fmt"
+)
+
+// CreditCardService는 신용카드 결제 서비스입니다.
+type CreditCardService struct {
+	cardNumber string
+	cvv        string
+}
+
+func NewCreditCardService(cardNumber, cvv string) *CreditCardService {
+	return &CreditCardService{
+		cardNumber: cardNumber,
+		cvv:        cvv,
+	}
+}
+
+func (s *CreditCardService) Pay(ctx context.Context, amount int) (PaymentResult, error) {
+	fmt.Printf("[CreditCard] Processing payment of %d won with card %s\n", amount, s.maskCardNumber())
+	return PaymentResult{
+		TransactionID: "CC-" + generateID(),
+		Status:        "SUCCESS",
+		Message:       "Credit card payment completed",
+	}, nil
+}
+
+func (s *CreditCardService) Refund(ctx context.Context, transactionID string) error {
+	fmt.Printf("[CreditCard] Refunding transaction %s\n", transactionID)
+	return nil
+}
+
+func (s *CreditCardService) GetName() string {
+	return "credit_card"
+}
+
+func (s *CreditCardService) maskCardNumber() string {
+	if len(s.cardNumber) < 4 {
+		return "****"
+	}
+	return "****-****-****-" + s.cardNumber[len(s.cardNumber)-4:]
+}

--- a/golang/pattern/strategy/domain.go
+++ b/golang/pattern/strategy/domain.go
@@ -1,0 +1,16 @@
+package strategy
+
+import "context"
+
+// PaymentStrategy는 결제 처리를 위한 전략 인터페이스입니다.
+type PaymentStrategy interface {
+	Pay(ctx context.Context, amount int) (PaymentResult, error)
+	Refund(ctx context.Context, transactionID string) error
+	GetName() string
+}
+
+type PaymentResult struct {
+	TransactionID string
+	Status        string
+	Message       string
+}

--- a/golang/pattern/strategy/helper.go
+++ b/golang/pattern/strategy/helper.go
@@ -1,0 +1,5 @@
+package strategy
+
+func generateID() string {
+	return "12345678"
+}

--- a/golang/pattern/strategy/kakao_pay_service.go
+++ b/golang/pattern/strategy/kakao_pay_service.go
@@ -1,0 +1,33 @@
+package strategy
+
+import (
+	"context"
+	"fmt"
+)
+
+// KakaoPayService는 카카오페이 결제 서비스입니다.
+type KakaoPayService struct {
+	userID string
+}
+
+func NewKakaoPayService(userID string) *KakaoPayService {
+	return &KakaoPayService{userID: userID}
+}
+
+func (s *KakaoPayService) Pay(ctx context.Context, amount int) (PaymentResult, error) {
+	fmt.Printf("[KakaoPay] Processing payment of %d won for user %s\n", amount, s.userID)
+	return PaymentResult{
+		TransactionID: "KP-" + generateID(),
+		Status:        "SUCCESS",
+		Message:       "KakaoPay payment completed",
+	}, nil
+}
+
+func (s *KakaoPayService) Refund(ctx context.Context, transactionID string) error {
+	fmt.Printf("[KakaoPay] Refunding transaction %s\n", transactionID)
+	return nil
+}
+
+func (s *KakaoPayService) GetName() string {
+	return "kakao_pay"
+}

--- a/golang/pattern/strategy/naver_pay_service.go
+++ b/golang/pattern/strategy/naver_pay_service.go
@@ -1,0 +1,33 @@
+package strategy
+
+import (
+	"context"
+	"fmt"
+)
+
+// NaverPayService는 네이버페이 결제 서비스입니다.
+type NaverPayService struct {
+	userID string
+}
+
+func NewNaverPayService(userID string) *NaverPayService {
+	return &NaverPayService{userID: userID}
+}
+
+func (s *NaverPayService) Pay(ctx context.Context, amount int) (PaymentResult, error) {
+	fmt.Printf("[NaverPay] Processing payment of %d won for user %s\n", amount, s.userID)
+	return PaymentResult{
+		TransactionID: "NP-" + generateID(),
+		Status:        "SUCCESS",
+		Message:       "NaverPay payment completed",
+	}, nil
+}
+
+func (s *NaverPayService) Refund(ctx context.Context, transactionID string) error {
+	fmt.Printf("[NaverPay] Refunding transaction %s\n", transactionID)
+	return nil
+}
+
+func (s *NaverPayService) GetName() string {
+	return "naver_pay"
+}

--- a/golang/pattern/strategy/payment_usecase.go
+++ b/golang/pattern/strategy/payment_usecase.go
@@ -1,0 +1,32 @@
+package strategy
+
+import (
+	"context"
+	"fmt"
+)
+
+// PaymentUsecase는 결제 유스케이스입니다.
+// Strategy를 주입받아 결제를 처리합니다.
+type PaymentUsecase struct {
+	strategy PaymentStrategy
+}
+
+func NewPaymentUsecase(strategy PaymentStrategy) *PaymentUsecase {
+	return &PaymentUsecase{strategy: strategy}
+}
+
+// SetStrategy는 런타임에 전략을 변경합니다.
+func (u *PaymentUsecase) SetStrategy(strategy PaymentStrategy) {
+	u.strategy = strategy
+}
+
+// ProcessPayment는 설정된 전략으로 결제를 처리합니다.
+func (u *PaymentUsecase) ProcessPayment(ctx context.Context, amount int) (PaymentResult, error) {
+	fmt.Printf("Processing payment with strategy: %s\n", u.strategy.GetName())
+	return u.strategy.Pay(ctx, amount)
+}
+
+// ProcessRefund는 설정된 전략으로 환불을 처리합니다.
+func (u *PaymentUsecase) ProcessRefund(ctx context.Context, transactionID string) error {
+	return u.strategy.Refund(ctx, transactionID)
+}


### PR DESCRIPTION
## Summary
- Strategy Pattern 예제 추가 (결제 시스템: 신용카드, 카카오페이, 네이버페이)
- Factory Pattern 예제 추가 (알림 시스템: 이메일, SMS, 푸시, Slack)
- 각 패턴별 README.md 파일에 Mermaid 클래스 다이어그램 포함

## 변경 파일
- `golang/pattern/strategy/` - Strategy Pattern 구현 및 README
- `golang/pattern/factory/` - Factory Pattern 구현 및 README
- `golang/pattern/example_test.go` - 테스트 예제

🤖 Generated with [Claude Code](https://claude.ai/code)