### PR TITLE
refactor: pattern 예제 pkg 디렉토리를 도메인명으로 변경

### DIFF
--- a/golang/pattern/factory/README.md
+++ b/golang/pattern/factory/README.md
@@ -65,14 +65,14 @@ classDiagram
 | 파일 | 설명 |
 |------|------|
 | `main.go` | 실행 진입점 (예제 코드) |
-| `pkg/domain.go` | `NotificationStrategy`, `NotificationStrategyProvider` 인터페이스 정의 |
-| `pkg/email_service.go` | 이메일 알림 서비스 구현체 |
-| `pkg/sms_service.go` | SMS 알림 서비스 구현체 |
-| `pkg/push_service.go` | 푸시 알림 서비스 구현체 |
-| `pkg/slack_service.go` | Slack 알림 서비스 구현체 |
-| `pkg/provider.go` | Strategy Provider (Factory) 구현 |
-| `pkg/notification_usecase.go` | 알림 유스케이스 (Context) |
-| `pkg/user_preference_store.go` | 사용자 설정 저장소 (Mock) |
+| `notification/domain.go` | `NotificationStrategy`, `NotificationStrategyProvider` 인터페이스 정의 |
+| `notification/email_service.go` | 이메일 알림 서비스 구현체 |
+| `notification/sms_service.go` | SMS 알림 서비스 구현체 |
+| `notification/push_service.go` | 푸시 알림 서비스 구현체 |
+| `notification/slack_service.go` | Slack 알림 서비스 구현체 |
+| `notification/provider.go` | Strategy Provider (Factory) 구현 |
+| `notification/notification_usecase.go` | 알림 유스케이스 (Context) |
+| `notification/user_preference_store.go` | 사용자 설정 저장소 (Mock) |
 
 ## 핵심 구성요소
 

--- a/golang/pattern/factory/main.go
+++ b/golang/pattern/factory/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/kenshin579/tutorials-go/golang/pattern/factory/pkg"
+	"github.com/kenshin579/tutorials-go/golang/pattern/factory/notification"
 )
 
 func main() {
@@ -16,16 +16,16 @@ func main() {
 	fmt.Println()
 
 	// 1. 각 Service 생성
-	emailService := pkg.NewEmailService("smtp.gmail.com", 587)
-	smsService := pkg.NewSMSService("api-key-123", "010-1234-5678")
-	pushService := pkg.NewPushService("fcm-token-abc")
-	slackService := pkg.NewSlackService("https://hooks.slack.com/xxx")
+	emailService := notification.NewEmailService("smtp.gmail.com", 587)
+	smsService := notification.NewSMSService("api-key-123", "010-1234-5678")
+	pushService := notification.NewPushService("fcm-token-abc")
+	slackService := notification.NewSlackService("https://hooks.slack.com/xxx")
 
 	// 2. UserPreferenceStore 생성 (사용자 설정 저장소)
-	userPrefStore := pkg.NewMockUserPreferenceStore()
+	userPrefStore := notification.NewMockUserPreferenceStore()
 
 	// 3. Strategy Provider(Factory) 생성
-	provider := pkg.NewNotificationStrategyProvider(
+	provider := notification.NewNotificationStrategyProvider(
 		emailService,
 		smsService,
 		pushService,
@@ -34,11 +34,11 @@ func main() {
 	)
 
 	// 4. NotificationUsecase 생성
-	notificationUsecase := pkg.NewNotificationUsecase(provider)
+	notificationUsecase := notification.NewNotificationUsecase(provider)
 
 	// 5. 타입을 직접 지정하여 알림 전송
 	fmt.Println("--- 타입 직접 지정 방식 ---")
-	_ = notificationUsecase.SendByType(ctx, pkg.NotificationTypeSlack, "#general", "Hello Slack!")
+	_ = notificationUsecase.SendByType(ctx, notification.NotificationTypeSlack, "#general", "Hello Slack!")
 	fmt.Println()
 
 	// 6. 사용자별 설정에 따라 자동으로 Strategy 선택

--- a/golang/pattern/factory/notification/domain.go
+++ b/golang/pattern/factory/notification/domain.go
@@ -1,4 +1,4 @@
-package pkg
+package notification
 
 import "context"
 

--- a/golang/pattern/factory/notification/email_service.go
+++ b/golang/pattern/factory/notification/email_service.go
@@ -1,4 +1,4 @@
-package pkg
+package notification
 
 import (
 	"context"

--- a/golang/pattern/factory/notification/notification_usecase.go
+++ b/golang/pattern/factory/notification/notification_usecase.go
@@ -1,4 +1,4 @@
-package pkg
+package notification
 
 import (
 	"context"

--- a/golang/pattern/factory/notification/provider.go
+++ b/golang/pattern/factory/notification/provider.go
@@ -1,4 +1,4 @@
-package pkg
+package notification
 
 import (
 	"context"

--- a/golang/pattern/factory/notification/push_service.go
+++ b/golang/pattern/factory/notification/push_service.go
@@ -1,4 +1,4 @@
-package pkg
+package notification
 
 import (
 	"context"

--- a/golang/pattern/factory/notification/slack_service.go
+++ b/golang/pattern/factory/notification/slack_service.go
@@ -1,4 +1,4 @@
-package pkg
+package notification
 
 import (
 	"context"

--- a/golang/pattern/factory/notification/sms_service.go
+++ b/golang/pattern/factory/notification/sms_service.go
@@ -1,4 +1,4 @@
-package pkg
+package notification
 
 import (
 	"context"

--- a/golang/pattern/factory/notification/user_preference_store.go
+++ b/golang/pattern/factory/notification/user_preference_store.go
@@ -1,4 +1,4 @@
-package pkg
+package notification
 
 import (
 	"context"

--- a/golang/pattern/strategy/README.md
+++ b/golang/pattern/strategy/README.md
@@ -54,12 +54,12 @@ classDiagram
 | 파일 | 설명 |
 |------|------|
 | `main.go` | 실행 진입점 (예제 코드) |
-| `pkg/domain.go` | `PaymentStrategy` 인터페이스 및 `PaymentResult` 타입 정의 |
-| `pkg/credit_card_service.go` | 신용카드 결제 서비스 구현체 |
-| `pkg/kakao_pay_service.go` | 카카오페이 결제 서비스 구현체 |
-| `pkg/naver_pay_service.go` | 네이버페이 결제 서비스 구현체 |
-| `pkg/payment_usecase.go` | 결제 유스케이스 (Context) |
-| `pkg/helper.go` | 헬퍼 함수 |
+| `payment/domain.go` | `PaymentStrategy` 인터페이스 및 `PaymentResult` 타입 정의 |
+| `payment/credit_card_service.go` | 신용카드 결제 서비스 구현체 |
+| `payment/kakao_pay_service.go` | 카카오페이 결제 서비스 구현체 |
+| `payment/naver_pay_service.go` | 네이버페이 결제 서비스 구현체 |
+| `payment/payment_usecase.go` | 결제 유스케이스 (Context) |
+| `payment/helper.go` | 헬퍼 함수 |
 
 ## 핵심 구성요소
 

--- a/golang/pattern/strategy/main.go
+++ b/golang/pattern/strategy/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/kenshin579/tutorials-go/golang/pattern/strategy/pkg"
+	"github.com/kenshin579/tutorials-go/golang/pattern/strategy/payment"
 )
 
 func main() {
@@ -16,15 +16,15 @@ func main() {
 	fmt.Println()
 
 	// 1. 신용카드 결제 서비스로 시작
-	creditCardService := pkg.NewCreditCardService("1234567890123456", "123")
-	paymentUsecase := pkg.NewPaymentUsecase(creditCardService)
+	creditCardService := payment.NewCreditCardService("1234567890123456", "123")
+	paymentUsecase := payment.NewPaymentUsecase(creditCardService)
 
 	fmt.Println("--- 신용카드로 결제 ---")
 	result, _ := paymentUsecase.ProcessPayment(ctx, 50000)
 	fmt.Printf("Result: %+v\n\n", result)
 
 	// 2. 런타임에 카카오페이 서비스로 전략 변경
-	kakaoPayService := pkg.NewKakaoPayService("user123")
+	kakaoPayService := payment.NewKakaoPayService("user123")
 	paymentUsecase.SetStrategy(kakaoPayService)
 
 	fmt.Println("--- 카카오페이로 결제 ---")
@@ -32,7 +32,7 @@ func main() {
 	fmt.Printf("Result: %+v\n\n", result)
 
 	// 3. 네이버페이 서비스로 전략 변경
-	naverPayService := pkg.NewNaverPayService("user456")
+	naverPayService := payment.NewNaverPayService("user456")
 	paymentUsecase.SetStrategy(naverPayService)
 
 	fmt.Println("--- 네이버페이로 결제 ---")

--- a/golang/pattern/strategy/payment/credit_card_service.go
+++ b/golang/pattern/strategy/payment/credit_card_service.go
@@ -1,4 +1,4 @@
-package pkg
+package payment
 
 import (
 	"context"

--- a/golang/pattern/strategy/payment/domain.go
+++ b/golang/pattern/strategy/payment/domain.go
@@ -1,4 +1,4 @@
-package pkg
+package payment
 
 import "context"
 

--- a/golang/pattern/strategy/payment/helper.go
+++ b/golang/pattern/strategy/payment/helper.go
@@ -1,4 +1,4 @@
-package pkg
+package payment
 
 func generateID() string {
 	return "12345678"

--- a/golang/pattern/strategy/payment/kakao_pay_service.go
+++ b/golang/pattern/strategy/payment/kakao_pay_service.go
@@ -1,4 +1,4 @@
-package pkg
+package payment
 
 import (
 	"context"

--- a/golang/pattern/strategy/payment/naver_pay_service.go
+++ b/golang/pattern/strategy/payment/naver_pay_service.go
@@ -1,4 +1,4 @@
-package pkg
+package payment
 
 import (
 	"context"

--- a/golang/pattern/strategy/payment/payment_usecase.go
+++ b/golang/pattern/strategy/payment/payment_usecase.go
@@ -1,4 +1,4 @@
-package pkg
+package payment
 
 import (
 	"context"


### PR DESCRIPTION
## Summary
- 영어와 한국어 사이에 스페이스 추가하여 코멘트 가독성 개선
- `pkg` 디렉토리를 도메인명으로 변경하여 패키지 의미 명확화
  - `strategy/pkg/` → `strategy/payment/` (`package payment`)
  - `factory/pkg/` → `factory/notification/` (`package notification`)
- import 경로, 참조, README 파일 구성 테이블 반영

🤖 Generated with [Claude Code](https://claude.com/claude-code)