### PR TITLE
refactor: factory 패턴에서 Mock 접두사 제거

### DIFF
--- a/golang/pattern/factory/main.go
+++ b/golang/pattern/factory/main.go
@@ -22,7 +22,7 @@ func main() {
 	slackService := notification.NewSlackService("https://hooks.slack.com/xxx")
 
 	// 2. UserPreferenceStore 생성 (사용자 설정 저장소)
-	userPrefStore := notification.NewMockUserPreferenceStore()
+	userPrefStore := notification.NewUserPreferenceStore()
 
 	// 3. Strategy Provider(Factory) 생성
 	provider := notification.NewNotificationStrategyProvider(

--- a/golang/pattern/factory/notification/user_preference_store.go
+++ b/golang/pattern/factory/notification/user_preference_store.go
@@ -5,13 +5,13 @@ import (
 	"errors"
 )
 
-// mockUserPreferenceStore 는 테스트/데모용 UserPreferenceStore 구현체입니다.
-type mockUserPreferenceStore struct {
+// userPreferenceStore 는 UserPreferenceStore 구현체입니다.
+type userPreferenceStore struct {
 	preferences map[string]NotificationType
 }
 
-func NewMockUserPreferenceStore() UserPreferenceStore {
-	return &mockUserPreferenceStore{
+func NewUserPreferenceStore() UserPreferenceStore {
+	return &userPreferenceStore{
 		preferences: map[string]NotificationType{
 			"user001": NotificationTypeEmail,
 			"user002": NotificationTypeSMS,
@@ -21,7 +21,7 @@ func NewMockUserPreferenceStore() UserPreferenceStore {
 	}
 }
 
-func (s *mockUserPreferenceStore) GetPreferredNotificationType(ctx context.Context, userID string) (NotificationType, error) {
+func (s *userPreferenceStore) GetPreferredNotificationType(ctx context.Context, userID string) (NotificationType, error) {
 	pref, ok := s.preferences[userID]
 	if !ok {
 		return "", errors.New("user preference not found")


### PR DESCRIPTION
## Summary
- `NewMockUserPreferenceStore` → `NewUserPreferenceStore`로 함수명 변경
- `mockUserPreferenceStore` → `userPreferenceStore`로 구조체명 변경
- 데모용 구현체에 불필요한 Mock 접두사를 제거하여 네이밍 정리

## Changed Files
- `golang/pattern/factory/main.go`
- `golang/pattern/factory/notification/user_preference_store.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)