### PR TITLE
feat: 그래프 자료구조 패키지 추가 (DFS, SCC, Reachability)

### DIFF
--- a/golang/data-structure/graph/graph.go
+++ b/golang/data-structure/graph/graph.go
@@ -1,0 +1,202 @@
+package graph
+
+import "sort"
+
+const (
+	White = iota // 미방문
+	Gray         // 진행 중
+	Black        // 완료
+)
+
+// Graph는 방향 그래프를 인접 리스트로 표현한다.
+type Graph struct {
+	adj map[int][]int
+}
+
+func NewGraph() *Graph {
+	return &Graph{adj: make(map[int][]int)}
+}
+
+// AddEdge는 u → v 간선을 추가한다.
+func (g *Graph) AddEdge(u, v int) {
+	g.adj[u] = append(g.adj[u], v)
+	if _, ok := g.adj[v]; !ok {
+		g.adj[v] = []int{}
+	}
+}
+
+// Vertices는 모든 정점을 정렬된 순서로 반환한다.
+func (g *Graph) Vertices() []int {
+	verts := make([]int, 0, len(g.adj))
+	for v := range g.adj {
+		verts = append(verts, v)
+	}
+	sort.Ints(verts)
+	return verts
+}
+
+// Transpose는 모든 간선의 방향을 뒤집은 전치 그래프를 반환한다.
+func (g *Graph) Transpose() *Graph {
+	gt := NewGraph()
+	for u, neighbors := range g.adj {
+		if _, ok := gt.adj[u]; !ok {
+			gt.adj[u] = []int{}
+		}
+		for _, v := range neighbors {
+			gt.adj[v] = append(gt.adj[v], u)
+		}
+	}
+	return gt
+}
+
+// DFSResult는 DFS 수행 결과를 담는다.
+type DFSResult struct {
+	Discovery   map[int]int       // 발견 시점
+	Finish      map[int]int       // 완료 시점
+	FinishOrder []int             // 완료 순서
+	EdgeType    map[[2]int]string // 간선 분류
+}
+
+// DFS는 타임스탬프와 간선 분류를 포함한 DFS를 수행한다.
+func (g *Graph) DFS() *DFSResult {
+	result := &DFSResult{
+		Discovery: make(map[int]int),
+		Finish:    make(map[int]int),
+		EdgeType:  make(map[[2]int]string),
+	}
+	color := make(map[int]int)
+	clock := 0
+
+	var visit func(u int)
+	visit = func(u int) {
+		clock++
+		result.Discovery[u] = clock
+		color[u] = Gray
+
+		for _, v := range g.adj[u] {
+			edge := [2]int{u, v}
+			switch color[v] {
+			case White:
+				result.EdgeType[edge] = "tree"
+				visit(v)
+			case Gray:
+				result.EdgeType[edge] = "back"
+			case Black:
+				if result.Discovery[u] < result.Discovery[v] {
+					result.EdgeType[edge] = "forward"
+				} else {
+					result.EdgeType[edge] = "cross"
+				}
+			}
+		}
+
+		color[u] = Black
+		clock++
+		result.Finish[u] = clock
+		result.FinishOrder = append(result.FinishOrder, u)
+	}
+
+	for _, v := range g.Vertices() {
+		if color[v] == White {
+			visit(v)
+		}
+	}
+	return result
+}
+
+// IsDAG는 그래프에 순환이 없는지(DAG인지) 확인한다.
+func (g *Graph) IsDAG() bool {
+	color := make(map[int]int)
+	for _, v := range g.Vertices() {
+		if color[v] == White {
+			if g.hasCycle(v, color) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func (g *Graph) hasCycle(u int, color map[int]int) bool {
+	color[u] = Gray
+	for _, v := range g.adj[u] {
+		if color[v] == Gray {
+			return true
+		}
+		if color[v] == White && g.hasCycle(v, color) {
+			return true
+		}
+	}
+	color[u] = Black
+	return false
+}
+
+// KahnTopologicalSort는 BFS 기반 위상정렬을 수행한다.
+// 순환이 있으면 nil을 반환한다.
+func (g *Graph) KahnTopologicalSort() []int {
+	inDegree := make(map[int]int)
+	for _, v := range g.Vertices() {
+		inDegree[v] = 0
+	}
+	for _, neighbors := range g.adj {
+		for _, v := range neighbors {
+			inDegree[v]++
+		}
+	}
+
+	queue := []int{}
+	for _, v := range g.Vertices() {
+		if inDegree[v] == 0 {
+			queue = append(queue, v)
+		}
+	}
+
+	result := []int{}
+	for len(queue) > 0 {
+		u := queue[0]
+		queue = queue[1:]
+		result = append(result, u)
+
+		for _, v := range g.adj[u] {
+			inDegree[v]--
+			if inDegree[v] == 0 {
+				queue = append(queue, v)
+			}
+		}
+	}
+
+	if len(result) != len(g.adj) {
+		return nil
+	}
+	return result
+}
+
+// TopologicalSortDFS는 DFS Finish Order의 역순으로 위상정렬을 수행한다.
+func (g *Graph) TopologicalSortDFS() []int {
+	color := make(map[int]int)
+	stack := []int{}
+
+	var dfs func(u int)
+	dfs = func(u int) {
+		color[u] = Gray
+		for _, v := range g.adj[u] {
+			if color[v] == White {
+				dfs(v)
+			}
+		}
+		color[u] = Black
+		stack = append(stack, u)
+	}
+
+	for _, v := range g.Vertices() {
+		if color[v] == White {
+			dfs(v)
+		}
+	}
+
+	result := make([]int, len(stack))
+	for i, v := range stack {
+		result[len(stack)-1-i] = v
+	}
+	return result
+}

--- a/golang/data-structure/graph/graph_test.go
+++ b/golang/data-structure/graph/graph_test.go
@@ -1,0 +1,140 @@
+package graph
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func buildDAG() *Graph {
+	// 0 → 1 → 3
+	// 0 → 2 → 3 → 4
+	g := NewGraph()
+	g.AddEdge(0, 1)
+	g.AddEdge(0, 2)
+	g.AddEdge(1, 3)
+	g.AddEdge(2, 3)
+	g.AddEdge(3, 4)
+	return g
+}
+
+func TestGraph_AddEdge(t *testing.T) {
+	g := NewGraph()
+	g.AddEdge(0, 1)
+	g.AddEdge(0, 2)
+
+	assert.Equal(t, []int{1, 2}, g.adj[0])
+	assert.Equal(t, []int{}, g.adj[1])
+	assert.Equal(t, []int{}, g.adj[2])
+}
+
+func TestGraph_Vertices(t *testing.T) {
+	g := buildDAG()
+	assert.Equal(t, []int{0, 1, 2, 3, 4}, g.Vertices())
+}
+
+func TestGraph_Transpose(t *testing.T) {
+	g := NewGraph()
+	g.AddEdge(0, 1)
+	g.AddEdge(1, 2)
+	g.AddEdge(2, 0)
+
+	gt := g.Transpose()
+
+	// 전치 그래프에서 1→0, 2→1, 0→2 간선이 있어야 한다
+	assert.Contains(t, gt.adj[1], 0)
+	assert.Contains(t, gt.adj[2], 1)
+	assert.Contains(t, gt.adj[0], 2)
+}
+
+func TestGraph_DFS(t *testing.T) {
+	g := buildDAG()
+	result := g.DFS()
+
+	// 모든 정점에 Discovery/Finish가 기록되었는지 확인
+	for _, v := range g.Vertices() {
+		assert.Contains(t, result.Discovery, v)
+		assert.Contains(t, result.Finish, v)
+		assert.Greater(t, result.Finish[v], result.Discovery[v])
+	}
+
+	// Tree Edge 확인
+	assert.Equal(t, "tree", result.EdgeType[[2]int{0, 1}])
+
+	// FinishOrder 길이 확인
+	assert.Equal(t, 5, len(result.FinishOrder))
+}
+
+func TestGraph_DFS_EdgeClassification(t *testing.T) {
+	// Back Edge가 있는 그래프
+	g := NewGraph()
+	g.AddEdge(0, 1)
+	g.AddEdge(1, 2)
+	g.AddEdge(2, 0) // Back Edge
+
+	result := g.DFS()
+
+	assert.Equal(t, "tree", result.EdgeType[[2]int{0, 1}])
+	assert.Equal(t, "tree", result.EdgeType[[2]int{1, 2}])
+	assert.Equal(t, "back", result.EdgeType[[2]int{2, 0}])
+}
+
+func TestGraph_IsDAG(t *testing.T) {
+	t.Run("DAG", func(t *testing.T) {
+		dag := buildDAG()
+		assert.True(t, dag.IsDAG())
+	})
+
+	t.Run("cyclic graph", func(t *testing.T) {
+		cyclic := NewGraph()
+		cyclic.AddEdge(0, 1)
+		cyclic.AddEdge(1, 2)
+		cyclic.AddEdge(2, 0)
+		assert.False(t, cyclic.IsDAG())
+	})
+}
+
+func TestGraph_KahnTopologicalSort(t *testing.T) {
+	t.Run("DAG", func(t *testing.T) {
+		g := buildDAG()
+		result := g.KahnTopologicalSort()
+
+		assert.NotNil(t, result)
+		assert.Equal(t, 5, len(result))
+
+		// 위상 순서 검증: 모든 간선 u→v에 대해 u가 v보다 앞에 있어야 한다
+		pos := make(map[int]int)
+		for i, v := range result {
+			pos[v] = i
+		}
+		edges := [][2]int{{0, 1}, {0, 2}, {1, 3}, {2, 3}, {3, 4}}
+		for _, e := range edges {
+			assert.Less(t, pos[e[0]], pos[e[1]], "edge %d→%d violated", e[0], e[1])
+		}
+	})
+
+	t.Run("cyclic graph returns nil", func(t *testing.T) {
+		g := NewGraph()
+		g.AddEdge(0, 1)
+		g.AddEdge(1, 2)
+		g.AddEdge(2, 0)
+
+		assert.Nil(t, g.KahnTopologicalSort())
+	})
+}
+
+func TestGraph_TopologicalSortDFS(t *testing.T) {
+	g := buildDAG()
+	result := g.TopologicalSortDFS()
+
+	assert.Equal(t, 5, len(result))
+
+	pos := make(map[int]int)
+	for i, v := range result {
+		pos[v] = i
+	}
+	edges := [][2]int{{0, 1}, {0, 2}, {1, 3}, {2, 3}, {3, 4}}
+	for _, e := range edges {
+		assert.Less(t, pos[e[0]], pos[e[1]], "edge %d→%d violated", e[0], e[1])
+	}
+}

--- a/golang/data-structure/graph/reachability.go
+++ b/golang/data-structure/graph/reachability.go
@@ -1,0 +1,45 @@
+package graph
+
+// Reachability는 O(1) 도달 가능성 판정을 위한 전처리 구조체다.
+// 교육 목적으로 map을 사용했다. 프로덕션에서는 []uint64 기반 bitset을 사용하면
+// OR 연산 한 번으로 도달 가능 집합을 합산할 수 있어 성능이 크게 향상된다.
+type Reachability struct {
+	scc   *SCCResult
+	reach map[int]map[int]bool // SCC ID → 도달 가능한 SCC ID 집합
+}
+
+// NewReachability는 그래프에 대해 전처리를 수행한다.
+func NewReachability(g *Graph) *Reachability {
+	// 1. SCC 분해
+	scc := g.Kosaraju()
+
+	// 2. DAG 축약
+	dag := g.Condense(scc)
+
+	// 3. 위상정렬 (Kahn)
+	topoOrder := dag.KahnTopologicalSort()
+
+	// 4. Bitset 역순 전파
+	reach := make(map[int]map[int]bool)
+	for i := range len(scc.Components) {
+		reach[i] = map[int]bool{i: true}
+	}
+
+	for i := len(topoOrder) - 1; i >= 0; i-- {
+		u := topoOrder[i]
+		for _, v := range dag.adj[u] {
+			for sccID := range reach[v] {
+				reach[u][sccID] = true
+			}
+		}
+	}
+
+	return &Reachability{scc: scc, reach: reach}
+}
+
+// IsReachable은 정점 from에서 정점 to로 도달 가능한지 O(1)으로 판정한다.
+func (r *Reachability) IsReachable(from, to int) bool {
+	sccFrom := r.scc.SCCOf[from]
+	sccTo := r.scc.SCCOf[to]
+	return r.reach[sccFrom][sccTo]
+}

--- a/golang/data-structure/graph/scc.go
+++ b/golang/data-structure/graph/scc.go
@@ -1,0 +1,95 @@
+package graph
+
+import "sort"
+
+// SCCResult는 Kosaraju SCC 결과를 담는다.
+type SCCResult struct {
+	SCCOf      map[int]int // 정점 → SCC ID
+	Components [][]int     // SCC ID → 정점 리스트
+}
+
+// Kosaraju는 2-pass DFS로 SCC를 구한다.
+func (g *Graph) Kosaraju() *SCCResult {
+	// Step 1: 1차 DFS — Finish Order 기록
+	finishOrder := []int{}
+	visited := make(map[int]bool)
+
+	var dfs1 func(u int)
+	dfs1 = func(u int) {
+		visited[u] = true
+		for _, v := range g.adj[u] {
+			if !visited[v] {
+				dfs1(v)
+			}
+		}
+		finishOrder = append(finishOrder, u)
+	}
+
+	for _, v := range g.Vertices() {
+		if !visited[v] {
+			dfs1(v)
+		}
+	}
+
+	// Step 2: 그래프 전치
+	gt := g.Transpose()
+
+	// Step 3: 2차 DFS — Finish Order 역순으로 전치 그래프 탐색
+	visited = make(map[int]bool)
+	result := &SCCResult{
+		SCCOf: make(map[int]int),
+	}
+	sccID := 0
+
+	var dfs2 func(u int, component *[]int)
+	dfs2 = func(u int, component *[]int) {
+		visited[u] = true
+		*component = append(*component, u)
+		result.SCCOf[u] = sccID
+		for _, v := range gt.adj[u] {
+			if !visited[v] {
+				dfs2(v, component)
+			}
+		}
+	}
+
+	for i := len(finishOrder) - 1; i >= 0; i-- {
+		u := finishOrder[i]
+		if !visited[u] {
+			component := []int{}
+			dfs2(u, &component)
+			sort.Ints(component)
+			result.Components = append(result.Components, component)
+			sccID++
+		}
+	}
+
+	return result
+}
+
+// Condense는 SCC를 하나의 노드로 축약한 DAG를 생성한다.
+func (g *Graph) Condense(scc *SCCResult) *Graph {
+	dag := NewGraph()
+
+	for i := range len(scc.Components) {
+		if _, ok := dag.adj[i]; !ok {
+			dag.adj[i] = []int{}
+		}
+	}
+
+	seen := make(map[[2]int]bool)
+	for u, neighbors := range g.adj {
+		for _, v := range neighbors {
+			su, sv := scc.SCCOf[u], scc.SCCOf[v]
+			if su != sv {
+				edge := [2]int{su, sv}
+				if !seen[edge] {
+					dag.AddEdge(su, sv)
+					seen[edge] = true
+				}
+			}
+		}
+	}
+
+	return dag
+}

--- a/golang/data-structure/graph/scc_test.go
+++ b/golang/data-structure/graph/scc_test.go
@@ -1,0 +1,117 @@
+package graph
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// 0 → 1 → 2 → 0 (SCC: {0,1,2})
+// 1 → 3 → 4 → 5 → 3 (SCC: {3,4,5})
+// 4 → 6 (SCC: {6})
+func buildSCCGraph() *Graph {
+	g := NewGraph()
+	g.AddEdge(0, 1)
+	g.AddEdge(1, 2)
+	g.AddEdge(2, 0)
+	g.AddEdge(1, 3)
+	g.AddEdge(3, 4)
+	g.AddEdge(4, 5)
+	g.AddEdge(5, 3)
+	g.AddEdge(4, 6)
+	return g
+}
+
+func TestGraph_Kosaraju(t *testing.T) {
+	g := buildSCCGraph()
+	scc := g.Kosaraju()
+
+	// SCC 3개
+	assert.Equal(t, 3, len(scc.Components))
+
+	// {0, 1, 2}는 같은 SCC
+	assert.Equal(t, scc.SCCOf[0], scc.SCCOf[1])
+	assert.Equal(t, scc.SCCOf[1], scc.SCCOf[2])
+
+	// {3, 4, 5}는 같은 SCC
+	assert.Equal(t, scc.SCCOf[3], scc.SCCOf[4])
+	assert.Equal(t, scc.SCCOf[4], scc.SCCOf[5])
+
+	// {6}은 별도 SCC
+	assert.NotEqual(t, scc.SCCOf[0], scc.SCCOf[3])
+	assert.NotEqual(t, scc.SCCOf[3], scc.SCCOf[6])
+	assert.NotEqual(t, scc.SCCOf[0], scc.SCCOf[6])
+}
+
+func TestGraph_Kosaraju_SingleNodes(t *testing.T) {
+	g := NewGraph()
+	g.AddEdge(0, 1)
+	g.AddEdge(2, 3)
+
+	scc := g.Kosaraju()
+
+	// 순환이 없으므로 각 정점이 독립 SCC
+	assert.Equal(t, 4, len(scc.Components))
+}
+
+func TestGraph_Condense(t *testing.T) {
+	g := buildSCCGraph()
+	scc := g.Kosaraju()
+	dag := g.Condense(scc)
+
+	// 축약 그래프의 정점 수 = SCC 수
+	assert.Equal(t, 3, len(dag.adj))
+
+	// 축약 그래프는 DAG
+	assert.True(t, dag.IsDAG())
+
+	// 위상정렬이 가능해야 한다
+	topo := dag.KahnTopologicalSort()
+	assert.NotNil(t, topo)
+	assert.Equal(t, 3, len(topo))
+}
+
+func TestReachability(t *testing.T) {
+	g := buildSCCGraph()
+	r := NewReachability(g)
+
+	t.Run("same SCC - reachable both ways", func(t *testing.T) {
+		// {0, 1, 2} 내부
+		assert.True(t, r.IsReachable(0, 1))
+		assert.True(t, r.IsReachable(1, 0))
+		assert.True(t, r.IsReachable(2, 0))
+
+		// {3, 4, 5} 내부
+		assert.True(t, r.IsReachable(3, 5))
+		assert.True(t, r.IsReachable(5, 3))
+	})
+
+	t.Run("cross SCC - forward reachable", func(t *testing.T) {
+		assert.True(t, r.IsReachable(0, 3))
+		assert.True(t, r.IsReachable(0, 6))
+		assert.True(t, r.IsReachable(1, 6))
+		assert.True(t, r.IsReachable(3, 6))
+	})
+
+	t.Run("cross SCC - backward not reachable", func(t *testing.T) {
+		assert.False(t, r.IsReachable(3, 0))
+		assert.False(t, r.IsReachable(6, 0))
+		assert.False(t, r.IsReachable(6, 3))
+	})
+}
+
+func TestReachability_DAG(t *testing.T) {
+	// 순환이 없는 단순 DAG
+	g := NewGraph()
+	g.AddEdge(0, 1)
+	g.AddEdge(1, 2)
+	g.AddEdge(0, 2)
+
+	r := NewReachability(g)
+
+	assert.True(t, r.IsReachable(0, 1))
+	assert.True(t, r.IsReachable(0, 2))
+	assert.True(t, r.IsReachable(1, 2))
+	assert.False(t, r.IsReachable(1, 0))
+	assert.False(t, r.IsReachable(2, 0))
+}


### PR DESCRIPTION
## Summary
- `golang/data-structure/graph/` 패키지 추가
  - `graph.go`: Graph 구조체, DFS (타임스탬프 + 간선 분류), Transpose, IsDAG, Kahn 위상정렬, DFS 위상정렬
  - `scc.go`: Kosaraju SCC 알고리즘, DAG 축약 (Condensation)
  - `reachability.go`: O(1) 도달 가능성 판정
  - `graph_test.go`: Graph 기본 테스트 8개
  - `scc_test.go`: SCC + Reachability 테스트 5개
- 블로그 글 연계: 그래프 기초 / SCC 알고리즘 블로그의 샘플 코드

## Test plan
- [x] `go test -v ./golang/data-structure/graph/...` — 13개 전체 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)