### PR TITLE
concurrency/select: 코드 코멘트 보강

### DIFF
--- a/golang/concurrency/select/basic_test.go
+++ b/golang/concurrency/select/basic_test.go
@@ -9,16 +9,16 @@ import (
 
 // TestSelectBasic - select로 여러 channel 동시 대기
 func TestSelectBasic(t *testing.T) {
-	ch1 := make(chan string, 1)
+	ch1 := make(chan string, 1) // 버퍼 1짜리 channel
 	ch2 := make(chan string, 1)
 
-	ch1 <- "from ch1"
+	ch1 <- "from ch1" // ch1에만 값이 있으므로 ch1 case가 선택됨
 
 	var result string
 	select {
-	case msg := <-ch1:
+	case msg := <-ch1: // ch1에서 먼저 데이터가 오면 실행
 		result = msg
-	case msg := <-ch2:
+	case msg := <-ch2: // ch2에서 먼저 데이터가 오면 실행
 		result = msg
 	}
 
@@ -27,25 +27,25 @@ func TestSelectBasic(t *testing.T) {
 
 // TestSelectMultipleReady - 여러 case가 동시에 준비되면 랜덤 선택
 func TestSelectMultipleReady(t *testing.T) {
-	ch1 := make(chan int, 1)
+	ch1 := make(chan int, 1) // 버퍼 1짜리 channel
 	ch2 := make(chan int, 1)
 
 	ch1Count := 0
 	ch2Count := 0
 	iterations := 1000
 
-	for range iterations {
-		ch1 <- 1
+	for range iterations { // 1000번 반복하여 선택 비율 확인
+		ch1 <- 1 // 두 channel에 동시에 값을 넣어 둘 다 준비 상태로 만듦
 		ch2 <- 2
 
 		select {
-		case <-ch1:
+		case <-ch1: // 두 case 모두 준비됐으므로 runtime이 무작위 선택
 			ch1Count++
 		case <-ch2:
 			ch2Count++
 		}
 
-		// 선택되지 않은 channel 비우기
+		// 선택되지 않은 channel의 남은 값 비우기
 		select {
 		case <-ch1:
 		case <-ch2:
@@ -61,7 +61,7 @@ func TestSelectMultipleReady(t *testing.T) {
 
 // TestSelectDefault - default case로 non-blocking 동작
 func TestSelectDefault(t *testing.T) {
-	ch := make(chan int)
+	ch := make(chan int) // unbuffered channel (데이터 없음)
 
 	var result string
 	select {
@@ -81,30 +81,30 @@ func TestSelectDefaultNonBlockingSend(t *testing.T) {
 
 	sent := false
 	select {
-	case ch <- 2:
+	case ch <- 2: // 버퍼가 가득 차서 send 불가
 		sent = true
 	default:
-		sent = false // 버퍼가 가득 차서 send 불가 → default 실행
+		sent = false // send 실패 시 즉시 default 실행
 	}
 
 	assert.False(t, sent)
 }
 
-// TestSelectWithTimer - select로 주기적 작업
+// TestSelectWithTimer - select로 주기적 작업 + timeout 조합
 func TestSelectWithTimer(t *testing.T) {
 	done := make(chan struct{})
 	var ticks int
 
 	go func() {
-		ticker := time.NewTicker(10 * time.Millisecond)
+		ticker := time.NewTicker(10 * time.Millisecond) // 10ms마다 tick
 		defer ticker.Stop()
-		timeout := time.After(55 * time.Millisecond)
+		timeout := time.After(55 * time.Millisecond) // 55ms 후 timeout
 
 		for {
 			select {
-			case <-ticker.C:
+			case <-ticker.C: // tick마다 카운트 증가
 				ticks++
-			case <-timeout:
+			case <-timeout: // timeout 발생 시 종료
 				close(done)
 				return
 			}

--- a/golang/concurrency/select/fanin_fanout_test.go
+++ b/golang/concurrency/select/fanin_fanout_test.go
@@ -12,33 +12,33 @@ import (
 
 // TestFanOut - 하나의 입력을 여러 worker에게 분배
 func TestFanOut(t *testing.T) {
-	jobs := make(chan int, 10)
+	jobs := make(chan int, 10) // 작업을 분배할 공유 channel
 	numWorkers := 3
 
-	// 결과를 모을 channels (worker별 하나)
+	// worker별 결과 channel 생성
 	workerResults := make([]chan int, numWorkers)
 	for i := range numWorkers {
 		workerResults[i] = make(chan int, 10)
 	}
 
-	// Fan-out: 각 worker가 jobs channel에서 작업을 가져감
+	// Fan-out: 각 worker가 같은 jobs channel에서 작업을 가져감
 	var wg sync.WaitGroup
 	for i := range numWorkers {
 		wg.Add(1)
-		go func() {
+		go func() { // 각 worker goroutine
 			defer wg.Done()
-			for job := range jobs {
-				workerResults[i] <- job * job // 제곱 계산
+			for job := range jobs { // jobs가 close되면 루프 종료
+				workerResults[i] <- job * job // 제곱 연산 후 결과 전송
 			}
 			close(workerResults[i])
 		}()
 	}
 
-	// 작업 투입
+	// 9개의 작업을 channel에 전송
 	for i := 1; i <= 9; i++ {
 		jobs <- i
 	}
-	close(jobs)
+	close(jobs) // 모든 작업 전송 완료 → worker들이 루프 종료
 
 	wg.Wait()
 
@@ -54,26 +54,25 @@ func TestFanOut(t *testing.T) {
 	assert.Equal(t, []int{1, 4, 9, 16, 25, 36, 49, 64, 81}, results)
 }
 
-// fanIn - 여러 channel을 하나로 합치는 함수
+// fanIn - 여러 channel의 값을 하나의 channel로 합치는 함수
 func fanIn(channels ...<-chan string) <-chan string {
 	var wg sync.WaitGroup
-	merged := make(chan string)
+	merged := make(chan string) // 모든 결과가 모이는 단일 channel
 
-	// 각 channel에서 값을 읽어 merged channel로 전달
+	// 각 source channel마다 goroutine이 값을 merged로 전달
 	for _, ch := range channels {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for v := range ch {
+			for v := range ch { // source channel이 close되면 루프 종료
 				merged <- v
 			}
 		}()
 	}
 
-	// 모든 channel이 닫히면 merged도 닫기
 	go func() {
-		wg.Wait()
-		close(merged)
+		wg.Wait()     // 모든 source가 완료될 때까지 대기
+		close(merged) // 모든 source 완료 후 merged channel 닫기
 	}()
 
 	return merged
@@ -111,17 +110,17 @@ func TestFanIn(t *testing.T) {
 	merged := fanIn(source1, source2, source3)
 
 	var results []string
-	for v := range merged {
+	for v := range merged { // merged channel이 close되면 루프 종료
 		results = append(results, v)
 	}
 
-	assert.Len(t, results, 9)
+	assert.Len(t, results, 9) // 각 source 3개씩 = 총 9개
 	t.Logf("merged results: %v", results)
 }
 
-// TestFanOutFanIn - fan-out + fan-in 조합
+// TestFanOutFanIn - fan-out + fan-in 조합으로 병렬 처리 파이프라인 구성
 func TestFanOutFanIn(t *testing.T) {
-	// 작업 생성 (generator)
+	// generator: 슬라이스를 channel로 변환하는 헬퍼
 	generator := func(nums ...int) <-chan int {
 		out := make(chan int)
 		go func() {
@@ -133,7 +132,7 @@ func TestFanOutFanIn(t *testing.T) {
 		return out
 	}
 
-	// worker: 입력을 제곱하여 출력
+	// square: 입력값을 제곱하여 문자열로 출력하는 worker
 	square := func(in <-chan int) <-chan string {
 		out := make(chan string)
 		go func() {
@@ -146,10 +145,9 @@ func TestFanOutFanIn(t *testing.T) {
 		return out
 	}
 
-	// Fan-out: 입력을 3개 worker에 분배
+	// Fan-out: 입력을 3개 worker에 라운드로빈으로 분배
 	input := generator(1, 2, 3, 4, 5, 6, 7, 8, 9)
 
-	// 입력을 버퍼링하여 worker에게 분배
 	worker1In := make(chan int, 9)
 	worker2In := make(chan int, 9)
 	worker3In := make(chan int, 9)
@@ -158,7 +156,7 @@ func TestFanOutFanIn(t *testing.T) {
 		i := 0
 		workers := []chan int{worker1In, worker2In, worker3In}
 		for n := range input {
-			workers[i%3] <- n
+			workers[i%3] <- n // 라운드로빈으로 작업 분배
 			i++
 		}
 		close(worker1In)

--- a/golang/concurrency/select/nil_channel_test.go
+++ b/golang/concurrency/select/nil_channel_test.go
@@ -8,11 +8,11 @@ import (
 
 // TestNilChannelBlock - nil channel은 send/receive 모두 영원히 blocking
 func TestNilChannelBlock(t *testing.T) {
-	var ch chan int // nil channel
+	var ch chan int // nil channel (초기화 안 함)
 
 	// nil channel에 대한 select는 해당 case를 무시한다
 	select {
-	case <-ch:
+	case <-ch: // nil channel이므로 이 case는 절대 선택되지 않음
 		t.Fatal("nil channel에서 receive할 수 없다")
 	default:
 		t.Log("nil channel은 select에서 무시됨")
@@ -24,29 +24,24 @@ func TestNilChannelDisable(t *testing.T) {
 	ch1 := make(chan int, 3)
 	ch2 := make(chan int, 3)
 
-	ch1 <- 1
-	ch1 <- 2
-	ch1 <- 3
-	close(ch1)
-
-	ch2 <- 10
-	ch2 <- 20
-	close(ch2)
+	ch1 <- 1; ch1 <- 2; ch1 <- 3; close(ch1) // ch1에 3개 값 전송 후 닫기
+	ch2 <- 10; ch2 <- 20; close(ch2)           // ch2에 2개 값 전송 후 닫기
 
 	var results []int
+	// receive 전용 channel 변수로 선언 — nil 할당으로 비활성화 가능
 	var active1, active2 = (<-chan int)(ch1), (<-chan int)(ch2)
 
-	for active1 != nil || active2 != nil {
+	for active1 != nil || active2 != nil { // 둘 다 nil이 되면 모든 데이터 소진
 		select {
 		case v, ok := <-active1:
 			if !ok {
-				active1 = nil // ch1이 닫히면 nil로 설정 → 이 case 비활성화
+				active1 = nil // 닫힌 channel → nil로 설정하면 select에서 무시됨
 				continue
 			}
 			results = append(results, v)
 		case v, ok := <-active2:
 			if !ok {
-				active2 = nil // ch2가 닫히면 nil로 설정 → 이 case 비활성화
+				active2 = nil // 같은 방식으로 ch2도 비활성화
 				continue
 			}
 			results = append(results, v)
@@ -54,7 +49,7 @@ func TestNilChannelDisable(t *testing.T) {
 	}
 
 	// 두 channel의 모든 값을 수신
-	assert.Len(t, results, 5) // ch1: 3개 + ch2: 2개
+	assert.Len(t, results, 5) // ch1: 3개 + ch2: 2개 = 총 5개
 	t.Logf("results: %v", results)
 }
 
@@ -64,12 +59,12 @@ func TestNilChannelMerge(t *testing.T) {
 	ch1 := make(chan int, 4)
 	ch2 := make(chan int, 4)
 
-	for _, v := range []int{1, 3, 5, 7} {
+	for _, v := range []int{1, 3, 5, 7} { // ch1: 홀수 값
 		ch1 <- v
 	}
 	close(ch1)
 
-	for _, v := range []int{2, 4, 6, 8} {
+	for _, v := range []int{2, 4, 6, 8} { // ch2: 짝수 값
 		ch2 <- v
 	}
 	close(ch2)
@@ -78,23 +73,23 @@ func TestNilChannelMerge(t *testing.T) {
 	var merged []int
 	var a, b = (<-chan int)(ch1), (<-chan int)(ch2)
 
-	for a != nil || b != nil {
+	for a != nil || b != nil { // 두 source 모두 소진될 때까지 반복
 		select {
 		case v, ok := <-a:
 			if !ok {
-				a = nil
+				a = nil // ch1 소진 → 비활성화
 				continue
 			}
 			merged = append(merged, v)
 		case v, ok := <-b:
 			if !ok {
-				b = nil
+				b = nil // ch2 소진 → 비활성화
 				continue
 			}
 			merged = append(merged, v)
 		}
 	}
 
-	assert.Len(t, merged, 8)
+	assert.Len(t, merged, 8) // 4개 + 4개 = 총 8개
 	t.Logf("merged: %v", merged)
 }

--- a/golang/concurrency/select/timeout_test.go
+++ b/golang/concurrency/select/timeout_test.go
@@ -12,9 +12,8 @@ import (
 func TestTimeoutWithTimeAfter(t *testing.T) {
 	ch := make(chan string)
 
-	// 느린 작업 시뮬레이션
 	go func() {
-		time.Sleep(200 * time.Millisecond)
+		time.Sleep(200 * time.Millisecond) // 200ms 걸리는 느린 작업 시뮬레이션
 		ch <- "result"
 	}()
 
@@ -22,9 +21,9 @@ func TestTimeoutWithTimeAfter(t *testing.T) {
 	var timedOut bool
 
 	select {
-	case msg := <-ch:
+	case msg := <-ch: // 작업 결과가 먼저 오면 정상 처리
 		result = msg
-	case <-time.After(50 * time.Millisecond):
+	case <-time.After(50 * time.Millisecond): // 50ms 초과 시 timeout channel에서 값 수신
 		timedOut = true
 	}
 
@@ -37,13 +36,13 @@ func TestTimeoutSuccess(t *testing.T) {
 	ch := make(chan string)
 
 	go func() {
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(10 * time.Millisecond) // 10ms만에 완료되는 빠른 작업
 		ch <- "fast result"
 	}()
 
 	var result string
 	select {
-	case msg := <-ch:
+	case msg := <-ch: // 100ms timeout 전에 결과 수신
 		result = msg
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("timeout")
@@ -54,17 +53,17 @@ func TestTimeoutSuccess(t *testing.T) {
 
 // TestTimeoutWithContext - context.WithTimeout으로 타임아웃 처리
 func TestTimeoutWithContext(t *testing.T) {
+	// 50ms timeout 설정
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
-	defer cancel()
+	defer cancel() // 리소스 해제를 위해 반드시 cancel 호출
 
 	ch := make(chan string)
 
-	// 느린 작업
 	go func() {
-		time.Sleep(200 * time.Millisecond)
+		time.Sleep(200 * time.Millisecond) // 200ms 걸리는 느린 작업
 		select {
 		case ch <- "result":
-		case <-ctx.Done():
+		case <-ctx.Done(): // context 취소 시 goroutine 정리
 			return
 		}
 	}()
@@ -72,30 +71,31 @@ func TestTimeoutWithContext(t *testing.T) {
 	select {
 	case msg := <-ch:
 		t.Fatalf("unexpected result: %s", msg)
-	case <-ctx.Done():
+	case <-ctx.Done(): // context timeout 초과 시 에러 반환
 		assert.ErrorIs(t, ctx.Err(), context.DeadlineExceeded)
 	}
 }
 
-// simulateAPICall - timeout이 있는 API 호출 시뮬레이션
+// simulateAPICall - context 기반 timeout이 적용된 API 호출 시뮬레이션
 func simulateAPICall(ctx context.Context, delay time.Duration) (string, error) {
-	ch := make(chan string, 1)
+	ch := make(chan string, 1) // 버퍼 1: goroutine이 결과를 보내고 바로 종료 가능
 
 	go func() {
-		time.Sleep(delay)
+		time.Sleep(delay) // API 호출 지연 시뮬레이션
 		ch <- "api response"
 	}()
 
 	select {
-	case result := <-ch:
+	case result := <-ch: // API 응답이 먼저 오면 정상 반환
 		return result, nil
-	case <-ctx.Done():
+	case <-ctx.Done(): // context timeout 초과 시 에러 반환
 		return "", ctx.Err()
 	}
 }
 
 // TestSimulateAPICallSuccess - API 호출 성공
 func TestSimulateAPICallSuccess(t *testing.T) {
+	// 100ms timeout — API는 10ms만에 완료
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
@@ -106,6 +106,7 @@ func TestSimulateAPICallSuccess(t *testing.T) {
 
 // TestSimulateAPICallTimeout - API 호출 타임아웃
 func TestSimulateAPICallTimeout(t *testing.T) {
+	// 50ms timeout — API는 200ms 걸리므로 timeout 발생
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 


### PR DESCRIPTION
블로그 Concurrency 3편과 동일한 수준으로 코드 코멘트 보강
- basic_test.go: select 기본, 랜덤 선택, default, timer
- timeout_test.go: time.After, context.WithTimeout, API 시뮬레이션
- fanin_fanout_test.go: Fan-out, Fan-in, 조합 파이프라인
- nil_channel_test.go: nil channel blocking, 동적 비활성화, merge