### PR TITLE
[chores] Go Concurrency trace 시각화 샘플 코드 추가

### DIFF
--- a/golang/concurrency/trace/basic_trace_test.go
+++ b/golang/concurrency/trace/basic_trace_test.go
@@ -1,0 +1,74 @@
+package _trace
+
+import (
+	"os"
+	rttrace "runtime/trace"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestBasicTrace_Start_Stop - trace.Start/Stop으로 기본 trace 수집
+// 수집된 trace 파일은 `go tool trace trace_basic.out` 으로 분석 가능
+func TestBasicTrace_Start_Stop(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "trace_basic_*.out")
+	assert.NoError(t, err)
+	defer f.Close()
+
+	// trace 수집 시작
+	err = rttrace.Start(f)
+	assert.NoError(t, err)
+
+	// 여러 goroutine에서 동시 작업 수행
+	var wg sync.WaitGroup
+	for i := range 5 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sum := 0
+			for range 1_000_000 {
+				sum++
+			}
+			t.Logf("goroutine %d: sum=%d", i, sum)
+		}()
+	}
+	wg.Wait()
+
+	// trace 수집 중지
+	rttrace.Stop()
+
+	// trace 파일이 생성되었는지 검증
+	info, err := f.Stat()
+	assert.NoError(t, err)
+	assert.Positive(t, info.Size(), "trace 파일이 비어있지 않아야 한다")
+	t.Logf("trace 파일: %s (크기: %d bytes)", f.Name(), info.Size())
+}
+
+// TestBasicTrace_GoTest_플래그 - go test -trace 플래그 사용 설명
+// 실행: go test -v -trace=trace_gotest.out -run TestBasicTrace_GoTest_플래그
+func TestBasicTrace_GoTest_플래그(t *testing.T) {
+	// go test -trace=trace.out 플래그를 사용하면
+	// 코드 수정 없이 테스트 실행 중 trace를 수집할 수 있다.
+	//
+	// 사용법:
+	//   go test -v -trace=trace_gotest.out ./golang/concurrency/trace/...
+	//   go tool trace trace_gotest.out
+	//
+	// 이 방법은 기존 테스트에 trace 코드를 추가하지 않고도
+	// goroutine 스케줄링, GC 활동 등을 분석할 수 있어 편리하다.
+
+	ch := make(chan int, 5)
+	go func() {
+		for i := range 5 {
+			ch <- i * i
+		}
+		close(ch)
+	}()
+
+	var results []int
+	for v := range ch {
+		results = append(results, v)
+	}
+	assert.Len(t, results, 5)
+}

--- a/golang/concurrency/trace/crawler_trace_test.go
+++ b/golang/concurrency/trace/crawler_trace_test.go
@@ -1,0 +1,190 @@
+package _trace
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	rttrace "runtime/trace"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCrawler_Task_Region_계측 - Worker Pool 기반 크롤러에 Task/Region/Log 계측 적용
+// httptest 서버를 사용하여 외부 의존성 없이 자체 포함(self-contained) 테스트를 구성한다.
+//
+// trace 분석 포인트:
+//  1. Task별 latency: 각 URL 크롤링에 걸린 시간
+//  2. Region별 시간: fetch vs parse 단계 비교
+//  3. Worker 활용률: goroutine이 idle인 시간 비율
+//  4. Blocking 분석: channel 대기, HTTP 응답 대기 등
+func TestCrawler_Task_Region_계측(t *testing.T) {
+	// trace 수집 설정
+	f, err := os.CreateTemp(t.TempDir(), "trace_crawler_*.out")
+	assert.NoError(t, err)
+	defer f.Close()
+
+	err = rttrace.Start(f)
+	assert.NoError(t, err)
+	defer rttrace.Stop()
+
+	// 테스트용 웹 서버 (가변 응답 시간)
+	pages := map[string]string{
+		"/":        `<a href="/about">About</a><a href="/blog">Blog</a>`,
+		"/about":   `<h1>About Us</h1><a href="/contact">Contact</a>`,
+		"/blog":    `<h1>Blog</h1><a href="/blog/post1">Post 1</a>`,
+		"/contact": `<h1>Contact</h1>`,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// 페이지별 다른 응답 시간 시뮬레이션
+		time.Sleep(time.Duration(len(r.URL.Path)) * time.Millisecond)
+		if body, ok := pages[r.URL.Path]; ok {
+			w.Header().Set("Content-Type", "text/html")
+			fmt.Fprint(w, body)
+		} else {
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	// 크롤러 실행
+	ctx := context.Background()
+	ctx, mainTask := rttrace.NewTask(ctx, "web-crawler")
+	defer mainTask.End()
+
+	results := crawl(ctx, server.URL, server.Client(), 3)
+
+	assert.NotEmpty(t, results, "크롤링 결과가 있어야 한다")
+	t.Logf("크롤링 완료: %d 페이지", len(results))
+	for _, r := range results {
+		t.Logf("  %s: %d bytes (%.1fms)", r.url, r.bodyLen, r.elapsed.Seconds()*1000)
+	}
+
+	info, _ := f.Stat()
+	assert.Positive(t, info.Size())
+	t.Logf("trace 파일: %s (%d bytes)", f.Name(), info.Size())
+}
+
+// crawlResult는 크롤링 결과를 담는 구조체
+type crawlResult struct {
+	url     string
+	bodyLen int
+	elapsed time.Duration
+}
+
+// crawl은 Worker Pool 패턴으로 URL을 크롤링하고 Task/Region으로 계측한다
+func crawl(ctx context.Context, baseURL string, client *http.Client, numWorkers int) []crawlResult {
+	urls := make(chan string, 20)
+	results := make(chan crawlResult, 20)
+
+	// 방문 추적 (중복 방지)
+	visited := &sync.Map{}
+
+	// Worker Pool 시작
+	var wg sync.WaitGroup
+	for w := range numWorkers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			workerName := fmt.Sprintf("crawler-worker-%d", w)
+
+			for url := range urls {
+				// 각 URL 크롤링을 Task로 계측
+				taskCtx, task := rttrace.NewTask(ctx, "crawl-page")
+				rttrace.Log(taskCtx, "url", url)
+				rttrace.Log(taskCtx, "worker", workerName)
+
+				result := fetchPage(taskCtx, client, url)
+				if result != nil {
+					results <- *result
+				}
+
+				task.End()
+			}
+		}()
+	}
+
+	// 시드 URL 투입
+	seedPaths := []string{"/", "/about", "/blog", "/contact"}
+	go func() {
+		for _, path := range seedPaths {
+			url := baseURL + path
+			if _, loaded := visited.LoadOrStore(url, true); !loaded {
+				urls <- url
+			}
+		}
+		close(urls)
+	}()
+
+	// Worker 완료 후 results 닫기
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	// 결과 수집
+	var collected []crawlResult
+	for r := range results {
+		collected = append(collected, r)
+	}
+	return collected
+}
+
+// fetchPage는 단일 페이지를 가져오고 Region으로 각 단계를 계측한다
+func fetchPage(ctx context.Context, client *http.Client, url string) *crawlResult {
+	start := time.Now()
+
+	var body []byte
+
+	// Region: HTTP 요청
+	rttrace.WithRegion(ctx, "http-fetch", func() {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			rttrace.Log(ctx, "error", err.Error())
+			return
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			rttrace.Log(ctx, "error", err.Error())
+			return
+		}
+		defer resp.Body.Close()
+
+		// 간단한 크기 제한 읽기
+		body = make([]byte, 0, 4096)
+		buf := make([]byte, 1024)
+		for {
+			n, readErr := resp.Body.Read(buf)
+			if n > 0 {
+				body = append(body, buf[:n]...)
+			}
+			if readErr != nil {
+				break
+			}
+		}
+
+		rttrace.Log(ctx, "status", fmt.Sprintf("%d", resp.StatusCode))
+	})
+
+	// Region: 파싱 (간단한 바이트 길이 계산으로 대체)
+	var bodyLen int
+	rttrace.WithRegion(ctx, "parse-html", func() {
+		bodyLen = len(body)
+		rttrace.Log(ctx, "bodySize", fmt.Sprintf("%d bytes", bodyLen))
+	})
+
+	elapsed := time.Since(start)
+	rttrace.Log(ctx, "elapsed", elapsed.String())
+
+	return &crawlResult{
+		url:     url,
+		bodyLen: bodyLen,
+		elapsed: elapsed,
+	}
+}

--- a/golang/concurrency/trace/flight_recorder_test.go
+++ b/golang/concurrency/trace/flight_recorder_test.go
@@ -1,0 +1,124 @@
+package _trace
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	rttrace "runtime/trace"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestFlightRecorder_HTTP서버_Latency_감지 - HTTP 서버에서 느린 요청 발생 시 자동 스냅샷 캡처
+// FlightRecorder는 링 버퍼 방식으로 항상 trace를 수집하다가,
+// 이상 징후(예: latency 초과) 발생 시 WriteTo로 스냅샷을 저장한다.
+//
+// 프로덕션 환경에서 간헐적으로 발생하는 tail latency 문제를
+// 사후에 분석할 수 있는 "블랙박스 레코더" 역할을 한다.
+func TestFlightRecorder_HTTP서버_Latency_감지(t *testing.T) {
+	const latencyThreshold = 50 * time.Millisecond
+
+	// FlightRecorder 설정
+	fr := rttrace.NewFlightRecorder(rttrace.FlightRecorderConfig{
+		MinAge:   200 * time.Millisecond,
+		MaxBytes: 1 << 20, // 1 MiB
+	})
+
+	err := fr.Start()
+	assert.NoError(t, err)
+	defer fr.Stop()
+	assert.True(t, fr.Enabled(), "FlightRecorder가 활성화되어야 한다")
+
+	// 가변 응답 시간 서버: 요청 번호에 따라 지연 시간이 달라짐
+	requestCount := 0
+	var mu sync.Mutex
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		count := requestCount
+		requestCount++
+		mu.Unlock()
+
+		// 5번째 요청마다 느린 응답 시뮬레이션
+		if count%5 == 4 {
+			time.Sleep(80 * time.Millisecond)
+		} else {
+			time.Sleep(5 * time.Millisecond)
+		}
+		fmt.Fprintf(w, "request-%d", count)
+	}))
+	defer server.Close()
+
+	// 클라이언트: 요청 보내면서 latency 초과 시 스냅샷 캡처
+	var snapshots []int64
+	client := server.Client()
+
+	for i := range 10 {
+		start := time.Now()
+
+		resp, err := client.Get(server.URL)
+		assert.NoError(t, err)
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+
+		elapsed := time.Since(start)
+		t.Logf("요청 %d: %v", i, elapsed)
+
+		// latency 초과 시 FlightRecorder 스냅샷 저장
+		if elapsed > latencyThreshold {
+			var buf bytes.Buffer
+			n, err := fr.WriteTo(&buf)
+			assert.NoError(t, err)
+			snapshots = append(snapshots, n)
+			t.Logf("  → 스냅샷 캡처! (크기: %d bytes, latency: %v)", n, elapsed)
+		}
+	}
+
+	// 느린 요청이 있었으므로 최소 1개 이상의 스냅샷이 캡처되어야 한다
+	assert.NotEmpty(t, snapshots, "latency 초과 시 스냅샷이 캡처되어야 한다")
+	for _, size := range snapshots {
+		assert.Positive(t, size, "스냅샷 데이터가 비어있지 않아야 한다")
+	}
+}
+
+// TestFlightRecorder_Start_Stop_라이프사이클 - FlightRecorder의 기본 라이프사이클
+func TestFlightRecorder_Start_Stop_라이프사이클(t *testing.T) {
+	fr := rttrace.NewFlightRecorder(rttrace.FlightRecorderConfig{
+		MinAge:   100 * time.Millisecond,
+		MaxBytes: 512 << 10, // 512 KiB
+	})
+
+	// 시작 전에는 비활성화 상태
+	assert.False(t, fr.Enabled())
+
+	// 시작
+	err := fr.Start()
+	assert.NoError(t, err)
+	assert.True(t, fr.Enabled())
+
+	// goroutine 활동으로 trace 데이터 생성
+	var wg sync.WaitGroup
+	for range 5 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			time.Sleep(10 * time.Millisecond)
+		}()
+	}
+	wg.Wait()
+
+	// 스냅샷 저장
+	var buf bytes.Buffer
+	n, err := fr.WriteTo(&buf)
+	assert.NoError(t, err)
+	assert.Positive(t, n, "스냅샷 데이터가 있어야 한다")
+	t.Logf("스냅샷 크기: %d bytes", n)
+
+	// 중지
+	fr.Stop()
+	assert.False(t, fr.Enabled(), "Stop 후 비활성화되어야 한다")
+}

--- a/golang/concurrency/trace/pprof_trace_combo_test.go
+++ b/golang/concurrency/trace/pprof_trace_combo_test.go
@@ -1,0 +1,121 @@
+package _trace
+
+import (
+	"net/http"
+	"net/http/httptest"
+	_ "net/http/pprof"
+	"os"
+	"runtime/pprof"
+	rttrace "runtime/trace"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestPprof_Trace_동시수집 - pprof CPU 프로파일과 trace를 동시에 수집
+//
+// pprof와 trace는 서로 다른 관점을 제공한다:
+//   - pprof: "무엇이 CPU/메모리를 소비하는가?" (샘플링, 통계적)
+//   - trace: "무슨 일이 어떤 순서로 일어났는가?" (정밀, 인과관계)
+//
+// 두 도구를 함께 사용하면:
+//  1. pprof로 CPU/메모리 핫스팟을 식별하고
+//  2. trace로 해당 구간의 동시성/타이밍을 분석하여
+//  3. 최적화 타겟을 정확히 결정할 수 있다
+func TestPprof_Trace_동시수집(t *testing.T) {
+	// 1. trace 파일 생성
+	traceFile, err := os.CreateTemp(t.TempDir(), "trace_combo_*.out")
+	assert.NoError(t, err)
+	defer traceFile.Close()
+
+	// 2. CPU 프로파일 파일 생성
+	cpuFile, err := os.CreateTemp(t.TempDir(), "cpu_combo_*.prof")
+	assert.NoError(t, err)
+	defer cpuFile.Close()
+
+	// 3. trace 수집 시작
+	err = rttrace.Start(traceFile)
+	assert.NoError(t, err)
+
+	// 4. CPU 프로파일 수집 시작
+	err = pprof.StartCPUProfile(cpuFile)
+	assert.NoError(t, err)
+
+	// 5. 워크로드 실행
+	var wg sync.WaitGroup
+	const numWorkers = 4
+	const numItems = 100
+
+	ch := make(chan int, numItems)
+	for i := range numItems {
+		ch <- i
+	}
+	close(ch)
+
+	for range numWorkers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for n := range ch {
+				// CPU 집중 작업
+				sum := 0
+				for i := range (n + 1) * 10_000 {
+					sum += i
+				}
+				_ = sum
+			}
+		}()
+	}
+	wg.Wait()
+
+	// 6. 수집 중지 (순서: trace → pprof)
+	rttrace.Stop()
+	pprof.StopCPUProfile()
+
+	// 7. 두 파일 모두 데이터가 있는지 검증
+	traceInfo, _ := traceFile.Stat()
+	cpuInfo, _ := cpuFile.Stat()
+
+	assert.Positive(t, traceInfo.Size(), "trace 파일이 비어있지 않아야 한다")
+	assert.Positive(t, cpuInfo.Size(), "CPU 프로파일이 비어있지 않아야 한다")
+
+	t.Logf("trace 파일: %s (%d bytes)", traceFile.Name(), traceInfo.Size())
+	t.Logf("CPU 프로파일: %s (%d bytes)", cpuFile.Name(), cpuInfo.Size())
+	t.Log("분석: go tool trace <trace파일> / go tool pprof <cpu프로파일>")
+}
+
+// TestPprof_HTTP_엔드포인트 - net/http/pprof 엔드포인트로 런타임 프로파일 확인
+// import _ "net/http/pprof"로 기본 엔드포인트가 등록된다.
+//
+// 주요 엔드포인트:
+//   - /debug/pprof/             : 인덱스 (사용 가능한 프로파일 목록)
+//   - /debug/pprof/profile      : CPU 프로파일 (기본 30초)
+//   - /debug/pprof/trace        : execution trace (기본 1초)
+//   - /debug/pprof/heap         : 메모리 할당 프로파일
+//   - /debug/pprof/goroutine    : goroutine 스택 덤프
+//   - /debug/pprof/block        : blocking 프로파일
+//   - /debug/pprof/mutex        : mutex 경합 프로파일
+func TestPprof_HTTP_엔드포인트(t *testing.T) {
+	// pprof 핸들러가 등록된 서버 생성
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", http.DefaultServeMux.ServeHTTP)
+
+	server := httptest.NewServer(http.DefaultServeMux)
+	defer server.Close()
+
+	// /debug/pprof/ 인덱스 페이지 접근
+	resp, err := http.Get(server.URL + "/debug/pprof/")
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// /debug/pprof/goroutine 접근
+	resp2, err := http.Get(server.URL + "/debug/pprof/goroutine?debug=1")
+	assert.NoError(t, err)
+	defer resp2.Body.Close()
+	assert.Equal(t, http.StatusOK, resp2.StatusCode)
+
+	t.Logf("pprof 서버: %s/debug/pprof/", server.URL)
+	t.Logf("trace 수집: curl -o trace.out '%s/debug/pprof/trace?seconds=5'", server.URL)
+}

--- a/golang/concurrency/trace/schedtrace_test.go
+++ b/golang/concurrency/trace/schedtrace_test.go
@@ -1,0 +1,142 @@
+package _trace
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSchedtrace_GODEBUG_출력_파싱 - GODEBUG=schedtrace로 스케줄러 상태 확인
+// subprocess로 실행하여 GODEBUG 환경변수의 효과를 검증한다.
+//
+// schedtrace 출력 형식:
+//
+//	SCHED 0ms: gomaxprocs=8 idleprocs=6 threads=4 spinningthreads=1
+//	  idlethreads=0 runqueue=0 [0 0 0 0 0 0 0 0]
+//
+// 각 필드:
+//   - gomaxprocs: GOMAXPROCS 값 (P의 수)
+//   - idleprocs: 유휴 P의 수
+//   - threads: OS 스레드(M) 수
+//   - spinningthreads: 실행할 goroutine을 찾고 있는 M 수
+//   - runqueue: 글로벌 실행 큐의 goroutine 수
+//   - []: 각 P의 로컬 실행 큐 goroutine 수
+func TestSchedtrace_GODEBUG_출력_파싱(t *testing.T) {
+	if os.Getenv("SCHEDTRACE_HELPER") == "1" {
+		// helper 프로세스: goroutine을 생성하여 스케줄러 활동 유발
+		var wg sync.WaitGroup
+		for range 50 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				sum := 0
+				for range 100_000 {
+					sum++
+				}
+			}()
+		}
+		wg.Wait()
+		return
+	}
+
+	// 메인 테스트: subprocess로 helper 실행
+	cmd := exec.Command(os.Args[0],
+		"-test.run=TestSchedtrace_GODEBUG_출력_파싱",
+		"-test.v",
+	)
+	cmd.Env = append(os.Environ(),
+		"SCHEDTRACE_HELPER=1",
+		"GODEBUG=schedtrace=100",
+	)
+
+	output, err := cmd.CombinedOutput()
+	outputStr := string(output)
+	t.Logf("schedtrace 출력:\n%s", outputStr)
+
+	// 프로세스가 정상 종료되어야 한다
+	assert.NoError(t, err, "subprocess 실행 실패: %s", outputStr)
+
+	// schedtrace 출력에 핵심 필드가 포함되어야 한다
+	assert.Contains(t, outputStr, "SCHED", "schedtrace 출력이 있어야 한다")
+	assert.Contains(t, outputStr, "gomaxprocs=", "gomaxprocs 필드가 있어야 한다")
+	assert.Contains(t, outputStr, "runqueue=", "runqueue 필드가 있어야 한다")
+}
+
+// TestSchedtrace_Scheddetail_상세출력 - scheddetail=1로 P/M/G 상세 정보 확인
+//
+// scheddetail=1 추가 시 P, M, G 각각의 상태가 출력된다:
+//   - P: status(idle/running/syscall), schedtick, syscalltick, 로컬 큐 정보
+//   - M: P 바인딩 상태, spinning 여부, blocked 여부
+//   - G: status(idle/runnable/running/syscall/waiting), 대기 이유
+//
+// Goroutine 상태 코드:
+//
+//	_Gidle(0): 생성 직후, 아직 초기화 안 됨
+//	_Grunnable(1): 실행 가능, 큐에서 대기 중
+//	_Grunning(2): M에서 실행 중
+//	_Gsyscall(3): 시스템 콜 실행 중
+//	_Gwaiting(4): 채널, 뮤텍스 등에서 블로킹
+func TestSchedtrace_Scheddetail_상세출력(t *testing.T) {
+	if os.Getenv("SCHEDDETAIL_HELPER") == "1" {
+		var wg sync.WaitGroup
+		ch := make(chan struct{})
+
+		// 대기 중인 goroutine 생성 (Gwaiting 상태)
+		for range 10 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-ch
+			}()
+		}
+
+		// 실행 중인 goroutine 생성 (Grunning/Grunnable 상태)
+		for range 10 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				sum := 0
+				for range 500_000 {
+					sum++
+				}
+			}()
+		}
+
+		runtime.Gosched() // 스케줄러에게 양보하여 출력 기회 제공
+		close(ch)
+		wg.Wait()
+		return
+	}
+
+	cmd := exec.Command(os.Args[0],
+		"-test.run=TestSchedtrace_Scheddetail_상세출력",
+		"-test.v",
+	)
+	cmd.Env = append(os.Environ(),
+		"SCHEDDETAIL_HELPER=1",
+		"GODEBUG=schedtrace=100,scheddetail=1",
+	)
+
+	output, err := cmd.CombinedOutput()
+	outputStr := string(output)
+
+	// 최대 2000자까지만 로깅 (scheddetail은 출력이 매우 길다)
+	logOutput := outputStr
+	if len(logOutput) > 2000 {
+		logOutput = logOutput[:2000] + "\n... (truncated)"
+	}
+	t.Logf("scheddetail 출력:\n%s", logOutput)
+
+	assert.NoError(t, err, "subprocess 실행 실패")
+	assert.Contains(t, outputStr, "SCHED")
+
+	// scheddetail 출력에는 P, M, G 상세 정보가 포함된다
+	hasDetail := strings.Contains(outputStr, "P") &&
+		(strings.Contains(outputStr, "M") || strings.Contains(outputStr, "G"))
+	assert.True(t, hasDetail, "scheddetail 출력에 P/M/G 정보가 있어야 한다")
+}

--- a/golang/concurrency/trace/task_region_test.go
+++ b/golang/concurrency/trace/task_region_test.go
@@ -1,0 +1,145 @@
+package _trace
+
+import (
+	"context"
+	"fmt"
+	"os"
+	rttrace "runtime/trace"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestTask_NewTask_End - trace.NewTask로 논리적 작업 단위 정의
+// Task는 여러 goroutine에 걸친 논리적 작업을 하나로 묶어준다.
+// go tool trace에서 Task별 latency 히스토그램을 확인할 수 있다.
+func TestTask_NewTask_End(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "trace_task_*.out")
+	assert.NoError(t, err)
+	defer f.Close()
+
+	err = rttrace.Start(f)
+	assert.NoError(t, err)
+	defer rttrace.Stop()
+
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	for i := range 3 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			// Task 생성 - trace 뷰에서 "order-process" 라벨로 표시
+			ctx, task := rttrace.NewTask(ctx, fmt.Sprintf("order-process-%d", i))
+			defer task.End()
+
+			// Task 내에서 로그 기록
+			rttrace.Log(ctx, "orderID", fmt.Sprintf("ORD-%04d", i))
+
+			// 작업 시뮬레이션
+			time.Sleep(time.Duration(i+1) * time.Millisecond)
+			rttrace.Log(ctx, "status", "completed")
+		}()
+	}
+	wg.Wait()
+
+	info, _ := f.Stat()
+	assert.Positive(t, info.Size())
+	t.Logf("Task trace 수집 완료: %s (%d bytes)", f.Name(), info.Size())
+}
+
+// TestRegion_WithRegion - trace.WithRegion으로 구간 측정
+// Region은 단일 goroutine 내에서 특정 구간의 시간을 측정한다.
+func TestRegion_WithRegion(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "trace_region_*.out")
+	assert.NoError(t, err)
+	defer f.Close()
+
+	err = rttrace.Start(f)
+	assert.NoError(t, err)
+	defer rttrace.Stop()
+
+	ctx := context.Background()
+	ctx, task := rttrace.NewTask(ctx, "data-pipeline")
+	defer task.End()
+
+	var result int
+
+	// WithRegion으로 구간 측정 - trace 뷰에서 구간별 시간 확인 가능
+	rttrace.WithRegion(ctx, "fetch-data", func() {
+		time.Sleep(2 * time.Millisecond)
+		result = 42
+	})
+
+	rttrace.WithRegion(ctx, "transform-data", func() {
+		result = result * 2
+	})
+
+	rttrace.WithRegion(ctx, "save-data", func() {
+		time.Sleep(1 * time.Millisecond)
+	})
+
+	assert.Equal(t, 84, result)
+}
+
+// TestRegion_StartRegion_End - StartRegion/End로 유연한 구간 측정
+// WithRegion과 달리 함수 클로저 바깥에서도 Region을 제어할 수 있다.
+func TestRegion_StartRegion_End(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "trace_startregion_*.out")
+	assert.NoError(t, err)
+	defer f.Close()
+
+	err = rttrace.Start(f)
+	assert.NoError(t, err)
+	defer rttrace.Stop()
+
+	ctx := context.Background()
+	ctx, task := rttrace.NewTask(ctx, "manual-region")
+	defer task.End()
+
+	// StartRegion으로 Region 시작
+	region := rttrace.StartRegion(ctx, "validation")
+	time.Sleep(1 * time.Millisecond)
+	region.End() // 명시적으로 종료
+
+	// 중첩(nested) Region
+	rttrace.WithRegion(ctx, "outer-region", func() {
+		rttrace.Log(ctx, "phase", "outer-start")
+
+		rttrace.WithRegion(ctx, "inner-region", func() {
+			rttrace.Log(ctx, "phase", "inner")
+			time.Sleep(1 * time.Millisecond)
+		})
+
+		rttrace.Log(ctx, "phase", "outer-end")
+	})
+}
+
+// TestLog_이벤트_마킹 - trace.Log로 trace에 커스텀 이벤트 기록
+// Log는 trace 타임라인에 특정 시점의 상태를 기록하여 디버깅에 활용한다.
+func TestLog_이벤트_마킹(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "trace_log_*.out")
+	assert.NoError(t, err)
+	defer f.Close()
+
+	err = rttrace.Start(f)
+	assert.NoError(t, err)
+
+	ctx := context.Background()
+	ctx, task := rttrace.NewTask(ctx, "http-handler")
+
+	// 다양한 카테고리의 로그 기록
+	rttrace.Log(ctx, "request", "GET /api/users")
+	rttrace.Log(ctx, "db-query", "SELECT * FROM users LIMIT 10")
+	rttrace.Log(ctx, "cache", "HIT user-list")
+	rttrace.Log(ctx, "response", "200 OK (15 items)")
+
+	task.End()
+	rttrace.Stop()
+
+	info, _ := f.Stat()
+	assert.Positive(t, info.Size())
+}


### PR DESCRIPTION
## Summary
- `golang/concurrency/trace/` 디렉토리에 go tool trace 관련 샘플 코드 6개 추가
- basic trace 수집, Task/Region/Log 계측, schedtrace, Flight Recorder, pprof+trace 조합, 크롤러 트레이싱

## 파일 목록
- `basic_trace_test.go` - trace.Start/Stop 기본 수집 + go test -trace 플래그 설명
- `task_region_test.go` - NewTask, WithRegion, StartRegion, Log API 데모
- `schedtrace_test.go` - GODEBUG=schedtrace subprocess 실행 및 출력 파싱
- `flight_recorder_test.go` - HTTP 서버 latency 감지 → FlightRecorder 스냅샷 캡처
- `pprof_trace_combo_test.go` - pprof CPU 프로파일 + trace 동시 수집, HTTP 엔드포인트
- `crawler_trace_test.go` - httptest 기반 크롤러에 Task/Region/Log 계측

## Test plan
- [x] `go test -v -race ./golang/concurrency/trace/...` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)