### PR TITLE
feat: Testcontainers 샘플 코드 보완 (Redis, MySQL, MongoDB)

### DIFF
--- a/go-unit-test/testcontainers/mongo_test.go
+++ b/go-unit-test/testcontainers/mongo_test.go
@@ -5,32 +5,83 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
 type mongoTestContainerTestSuite struct {
 	suite.Suite
-	ctx context.Context
-
-	mongoClient    *mongo.Client
-	lockCollection *mongo.Collection
+	ctx        context.Context
+	client     *mongo.Client
+	collection *mongo.Collection
 }
 
 func TestMongoTestSuite(t *testing.T) {
 	suite.Run(t, new(mongoTestContainerTestSuite))
 }
 
-func (suite *mongoTestContainerTestSuite) SetupSuite() {
-	suite.ctx = context.Background()
-
+func (s *mongoTestContainerTestSuite) SetupSuite() {
+	s.ctx = context.Background()
+	s.client = NewMongoClient()
+	s.collection = s.client.Database("testdb").Collection("items")
 }
 
-func (suite *mongoTestContainerTestSuite) TearDownTest() {
-	// suite.NoError(suite.redisV9Client.FlushAll(suite.ctx).Err())
+func (s *mongoTestContainerTestSuite) TearDownTest() {
+	s.NoError(s.collection.Drop(s.ctx))
 }
 
-func (suite *mongoTestContainerTestSuite) Test_MongoTestContainers() {
-	suite.Run("Test Set and Get", func() {
+func (s *mongoTestContainerTestSuite) Test_InsertAndFind() {
+	doc := bson.M{"name": "testcontainers", "language": "go"}
+	_, err := s.collection.InsertOne(s.ctx, doc)
+	s.NoError(err)
 
-	})
+	var result bson.M
+	err = s.collection.FindOne(s.ctx, bson.M{"name": "testcontainers"}).Decode(&result)
+	s.NoError(err)
+	s.Equal("testcontainers", result["name"])
+	s.Equal("go", result["language"])
+}
+
+func (s *mongoTestContainerTestSuite) Test_InsertManyAndCount() {
+	docs := []interface{}{
+		bson.M{"name": "redis", "type": "cache"},
+		bson.M{"name": "mongo", "type": "document"},
+		bson.M{"name": "mysql", "type": "relational"},
+	}
+	_, err := s.collection.InsertMany(s.ctx, docs)
+	s.NoError(err)
+
+	count, err := s.collection.CountDocuments(s.ctx, bson.M{})
+	s.NoError(err)
+	s.Equal(int64(3), count)
+}
+
+func (s *mongoTestContainerTestSuite) Test_UpdateOne() {
+	doc := bson.M{"name": "old", "version": 1}
+	_, err := s.collection.InsertOne(s.ctx, doc)
+	s.NoError(err)
+
+	_, err = s.collection.UpdateOne(s.ctx,
+		bson.M{"name": "old"},
+		bson.M{"$set": bson.M{"name": "new", "version": 2}},
+	)
+	s.NoError(err)
+
+	var result bson.M
+	s.NoError(s.collection.FindOne(s.ctx, bson.M{"name": "new"}).Decode(&result))
+	s.Equal(int32(2), result["version"])
+}
+
+func (s *mongoTestContainerTestSuite) Test_DeleteOne() {
+	doc := bson.M{"name": "to-delete"}
+	_, err := s.collection.InsertOne(s.ctx, doc)
+	s.NoError(err)
+
+	res, err := s.collection.DeleteOne(s.ctx, bson.M{"name": "to-delete"})
+	s.NoError(err)
+	s.Equal(int64(1), res.DeletedCount)
+
+	count, err := s.collection.CountDocuments(s.ctx, bson.M{"name": "to-delete"})
+	s.NoError(err)
+	s.Equal(int64(0), count)
 }

--- a/go-unit-test/testcontainers/mysql.go
+++ b/go-unit-test/testcontainers/mysql.go
@@ -2,50 +2,63 @@ package go_testcontainers
 
 import (
 	"context"
-	"testing"
+	"fmt"
+	"time"
 
 	"github.com/docker/go-connections/nat"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	mysqlDriver "gorm.io/driver/mysql"
+	"gorm.io/gorm"
 )
 
-func NewMysqlDB() {
+func NewMysqlDB() *gorm.DB {
+	password, database := "root", "test_db"
+	host, port, err := startMysqlContainer(password, database)
+	if err != nil {
+		panic(err)
+	}
 
+	dsn := fmt.Sprintf("root:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=true", password, host, port, database)
+	db, err := gorm.Open(mysqlDriver.Open(dsn), &gorm.Config{})
+	if err != nil {
+		panic(err)
+	}
+
+	return db
 }
 
-func createMysqlContainer(ctx context.Context, tb testing.TB, password, database string) (string, string, error) {
+func startMysqlContainer(password, database string) (string, string, error) {
+	ctx := context.Background()
 	port := "3306"
-	req := testcontainers.GenericContainerRequest{
-		Logger: testcontainers.TestLogger(tb),
-		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "mysql:8",
-			ExposedPorts: []string{port + "/tcp"},
-			// HostConfigModifier: func(config *container.HostConfig) {
-			// 	config.AutoRemove = true
-			// },
-			Env: map[string]string{
-				"MYSQL_DATABASE":      database,
-				"MYSQL_ROOT_PASSWORD": password,
-			},
-			AlwaysPullImage: false,
-			// WaitingFor: wait.ForSQL(nat.Port(port), "mysql", func(host string, port nat.Port) string {
-			// 	return fmt.Sprintf("root:%v@tcp(%v:%v)/%v?charset=utf8mb4&parseTime=true", password, host, port.Port(), database)
-			// }).WithPollInterval(3 * time.Second),
+
+	req := testcontainers.ContainerRequest{
+		Image:        "mysql:8",
+		ExposedPorts: []string{port + "/tcp"},
+		Env: map[string]string{
+			"MYSQL_DATABASE":      database,
+			"MYSQL_ROOT_PASSWORD": password,
 		},
-		Started: true,
+		WaitingFor: wait.ForSQL(nat.Port(port), "mysql", func(port nat.Port) string {
+			return fmt.Sprintf("root:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=true", password, "localhost", port.Port(), database)
+		}).WithPollInterval(3 * time.Second),
 	}
 
-	genericContainer, err := testcontainers.GenericContainer(ctx, req)
+	mysqlC, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
 	if err != nil {
 		return "", "", err
 	}
 
-	host, err := genericContainer.Host(ctx)
+	host, err := mysqlC.Host(ctx)
 	if err != nil {
 		return "", "", err
 	}
 
-	mappedPort, err := genericContainer.MappedPort(ctx, nat.Port(port))
+	mappedPort, err := mysqlC.MappedPort(ctx, nat.Port(port))
 	if err != nil {
 		return "", "", err
 	}

--- a/go-unit-test/testcontainers/mysql_test.go
+++ b/go-unit-test/testcontainers/mysql_test.go
@@ -1,0 +1,66 @@
+package go_testcontainers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+)
+
+type User struct {
+	gorm.Model
+	Name  string
+	Email string
+}
+
+type mysqlTestContainerTestSuite struct {
+	suite.Suite
+	db *gorm.DB
+}
+
+func TestMysqlTestSuite(t *testing.T) {
+	suite.Run(t, new(mysqlTestContainerTestSuite))
+}
+
+func (s *mysqlTestContainerTestSuite) SetupSuite() {
+	s.db = NewMysqlDB()
+	s.NoError(s.db.AutoMigrate(&User{}))
+}
+
+func (s *mysqlTestContainerTestSuite) TearDownTest() {
+	s.db.Exec("DELETE FROM users")
+}
+
+func (s *mysqlTestContainerTestSuite) Test_CreateAndFind() {
+	user := User{Name: "Frank", Email: "frank@example.com"}
+	result := s.db.Create(&user)
+	s.NoError(result.Error)
+	s.NotZero(user.ID)
+
+	var found User
+	s.NoError(s.db.First(&found, user.ID).Error)
+	s.Equal("Frank", found.Name)
+	s.Equal("frank@example.com", found.Email)
+}
+
+func (s *mysqlTestContainerTestSuite) Test_Update() {
+	user := User{Name: "Alice", Email: "alice@example.com"}
+	s.db.Create(&user)
+
+	s.NoError(s.db.Model(&user).Update("Email", "alice@newmail.com").Error)
+
+	var updated User
+	s.db.First(&updated, user.ID)
+	s.Equal("alice@newmail.com", updated.Email)
+}
+
+func (s *mysqlTestContainerTestSuite) Test_Delete() {
+	user := User{Name: "Bob", Email: "bob@example.com"}
+	s.db.Create(&user)
+
+	s.NoError(s.db.Delete(&user).Error)
+
+	var found User
+	err := s.db.First(&found, user.ID).Error
+	s.ErrorIs(err, gorm.ErrRecordNotFound)
+}

--- a/go-unit-test/testcontainers/redis_test.go
+++ b/go-unit-test/testcontainers/redis_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	redislib_v9 "github.com/go-redis/redis/v9"
-	"github.com/kenshin579/tutorials-go/test/testcontainers"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -21,7 +20,7 @@ func TestRedisTestSuite(t *testing.T) {
 }
 
 func (suite *redisTestContainerTestSuite) SetupSuite() {
-	redisV9Client := testcontainers.NewRedisV9Client()
+	redisV9Client := NewRedisV9Client()
 	suite.ctx = context.Background()
 	suite.redisV9Client = redisV9Client
 


### PR DESCRIPTION
## Summary
- `redis_test.go`: 깨진 import 수정 (존재하지 않는 패키지 → 같은 패키지 직접 호출)
- `mysql.go`: `NewMysqlDB()` 완성 (`wait.ForSQL` v0.13.0 시그니처, GORM 연결)
- `mysql_test.go`: GORM CRUD Suite 테스트 신규 작성 (Create+Find, Update, Delete)
- `mongo_test.go`: 빈 skeleton → Insert/Find, InsertMany/Count, Update, Delete 테스트 추가

## Test plan
- [ ] `go test -v -run TestRedisTestSuite ./go-unit-test/testcontainers/...`
- [ ] `go test -v -run TestMysqlTestSuite ./go-unit-test/testcontainers/...`
- [ ] `go test -v -run TestMongoTestSuite ./go-unit-test/testcontainers/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)