### PR TITLE
feat: Go Redis 블로그 샘플 코드 추가 (Pub/Sub, Stream, miniredis)

### DIFF
--- a/database/redis/redis/miniredis_test.go
+++ b/database/redis/redis/miniredis_test.go
@@ -1,0 +1,101 @@
+package redis
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+)
+
+func newMiniredisClient(t *testing.T) (*redis.Client, *miniredis.Miniredis) {
+	t.Helper()
+	s := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{
+		Addr: s.Addr(),
+	})
+	return rdb, s
+}
+
+func Test_Miniredis_Basic(t *testing.T) {
+	rdb, _ := newMiniredisClient(t)
+	ctx := context.Background()
+
+	// Set/Get
+	err := rdb.Set(ctx, "name", "frank", 0).Err()
+	assert.NoError(t, err)
+
+	val, err := rdb.Get(ctx, "name").Result()
+	assert.NoError(t, err)
+	assert.Equal(t, "frank", val)
+
+	// 존재하지 않는 키
+	_, err = rdb.Get(ctx, "nonexistent").Result()
+	assert.ErrorIs(t, err, redis.Nil)
+}
+
+func Test_Miniredis_TTL(t *testing.T) {
+	rdb, s := newMiniredisClient(t)
+	ctx := context.Background()
+
+	// TTL이 있는 키 설정
+	err := rdb.Set(ctx, "session", "token-abc", 10*time.Minute).Err()
+	assert.NoError(t, err)
+
+	// 키 존재 확인
+	val, err := rdb.Get(ctx, "session").Result()
+	assert.NoError(t, err)
+	assert.Equal(t, "token-abc", val)
+
+	// FastForward로 시간 경과 시뮬레이션
+	s.FastForward(11 * time.Minute)
+
+	// TTL 만료 후 키 사라짐
+	_, err = rdb.Get(ctx, "session").Result()
+	assert.ErrorIs(t, err, redis.Nil)
+}
+
+func Test_Miniredis_SortedSet(t *testing.T) {
+	rdb, _ := newMiniredisClient(t)
+	ctx := context.Background()
+
+	// 리더보드 데이터 추가
+	rdb.ZAdd(ctx, "leaderboard", redis.Z{Score: 100, Member: "player1"})
+	rdb.ZAdd(ctx, "leaderboard", redis.Z{Score: 250, Member: "player2"})
+	rdb.ZAdd(ctx, "leaderboard", redis.Z{Score: 180, Member: "player3"})
+
+	// 상위 랭킹 조회 (점수 높은 순)
+	result, err := rdb.ZRevRangeWithScores(ctx, "leaderboard", 0, -1).Result()
+	assert.NoError(t, err)
+	assert.Len(t, result, 3)
+	assert.Equal(t, "player2", result[0].Member)
+	assert.Equal(t, float64(250), result[0].Score)
+
+	// 특정 멤버 순위 조회 (0-based, 높은 점수 순)
+	rank, err := rdb.ZRevRank(ctx, "leaderboard", "player2").Result()
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), rank)
+}
+
+func Test_Miniredis_PubSub(t *testing.T) {
+	rdb, _ := newMiniredisClient(t)
+	ctx := context.Background()
+
+	// 구독
+	sub := rdb.Subscribe(ctx, "test-channel")
+	defer sub.Close()
+
+	_, err := sub.Receive(ctx)
+	assert.NoError(t, err)
+
+	// 발행
+	rdb.Publish(ctx, "test-channel", "hello miniredis")
+
+	// 수신
+	msg, err := sub.ReceiveMessage(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, "test-channel", msg.Channel)
+	assert.Equal(t, "hello miniredis", msg.Payload)
+}

--- a/database/redis/redis/pubsub_test.go
+++ b/database/redis/redis/pubsub_test.go
@@ -1,0 +1,125 @@
+package redis
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+)
+
+func newPubSubClient(t *testing.T) *redis.Client {
+	t.Helper()
+	s := miniredis.RunT(t)
+	return redis.NewClient(&redis.Options{Addr: s.Addr()})
+}
+
+func Test_PubSub_Basic(t *testing.T) {
+	rdb := newPubSubClient(t)
+	ctx := context.Background()
+
+	// 채널 구독
+	sub := rdb.Subscribe(ctx, "notifications")
+	defer sub.Close()
+
+	// 구독 확인 대기
+	_, err := sub.Receive(ctx)
+	assert.NoError(t, err)
+
+	// 메시지 발행
+	err = rdb.Publish(ctx, "notifications", "hello redis pubsub").Err()
+	assert.NoError(t, err)
+
+	// 메시지 수신
+	msg, err := sub.ReceiveMessage(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, "notifications", msg.Channel)
+	assert.Equal(t, "hello redis pubsub", msg.Payload)
+}
+
+func Test_PubSub_PatternSubscribe(t *testing.T) {
+	rdb := newPubSubClient(t)
+	ctx := context.Background()
+
+	// 패턴 구독: news.* 채널 전체 매칭
+	sub := rdb.PSubscribe(ctx, "news.*")
+	defer sub.Close()
+
+	_, err := sub.Receive(ctx)
+	assert.NoError(t, err)
+
+	// 다른 채널로 발행
+	rdb.Publish(ctx, "news.tech", "Go 1.22 released")
+	rdb.Publish(ctx, "news.sports", "World Cup 2026")
+
+	// 두 메시지 모두 수신
+	msg1, err := sub.ReceiveMessage(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, "news.tech", msg1.Channel)
+	assert.Equal(t, "news.*", msg1.Pattern)
+	assert.Equal(t, "Go 1.22 released", msg1.Payload)
+
+	msg2, err := sub.ReceiveMessage(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, "news.sports", msg2.Channel)
+	assert.Equal(t, "World Cup 2026", msg2.Payload)
+}
+
+func Test_PubSub_MultiChannel(t *testing.T) {
+	rdb := newPubSubClient(t)
+	ctx := context.Background()
+
+	// 다중 채널 동시 구독
+	sub := rdb.Subscribe(ctx, "channel-1", "channel-2", "channel-3")
+	defer sub.Close()
+
+	_, err := sub.Receive(ctx)
+	assert.NoError(t, err)
+
+	// 각 채널에 메시지 발행
+	messages := map[string]string{
+		"channel-1": "msg-1",
+		"channel-2": "msg-2",
+		"channel-3": "msg-3",
+	}
+
+	for ch, msg := range messages {
+		err := rdb.Publish(ctx, ch, msg).Err()
+		assert.NoError(t, err)
+	}
+
+	// Channel()을 사용한 수신 (goroutine 패턴)
+	ch := sub.Channel()
+	received := make(map[string]string)
+	var mu sync.Mutex
+
+	done := make(chan struct{})
+	go func() {
+		for msg := range ch {
+			mu.Lock()
+			received[msg.Channel] = msg.Payload
+			if len(received) == 3 {
+				mu.Unlock()
+				close(done)
+				return
+			}
+			mu.Unlock()
+		}
+	}()
+
+	select {
+	case <-done:
+		// 성공
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for messages")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, "msg-1", received["channel-1"])
+	assert.Equal(t, "msg-2", received["channel-2"])
+	assert.Equal(t, "msg-3", received["channel-3"])
+}

--- a/database/redis/redis/redis_test.go
+++ b/database/redis/redis/redis_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/kenshin579/tutorials-go/go-redis/model"
+	"github.com/kenshin579/tutorials-go/database/redis/model"
 
 	"github.com/go-redis/redis/v8"
 	"github.com/stretchr/testify/assert"

--- a/database/redis/redis/stream_test.go
+++ b/database/redis/redis/stream_test.go
@@ -1,0 +1,152 @@
+package redis
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+)
+
+func newStreamClient(t *testing.T) *redis.Client {
+	t.Helper()
+	s := miniredis.RunT(t)
+	return redis.NewClient(&redis.Options{Addr: s.Addr()})
+}
+
+func Test_Stream_XAdd_XRead(t *testing.T) {
+	rdb := newStreamClient(t)
+	ctx := context.Background()
+
+	// XADD - 메시지 추가
+	id1, err := rdb.XAdd(ctx, &redis.XAddArgs{
+		Stream: "mystream",
+		Values: map[string]interface{}{
+			"user":   "frank",
+			"action": "login",
+		},
+	}).Result()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, id1)
+
+	id2, err := rdb.XAdd(ctx, &redis.XAddArgs{
+		Stream: "mystream",
+		Values: map[string]interface{}{
+			"user":   "angela",
+			"action": "purchase",
+		},
+	}).Result()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, id2)
+
+	// XREAD - 메시지 읽기 (처음부터)
+	streams, err := rdb.XRead(ctx, &redis.XReadArgs{
+		Streams: []string{"mystream", "0"},
+		Count:   10,
+	}).Result()
+	assert.NoError(t, err)
+	assert.Len(t, streams, 1)
+	assert.Len(t, streams[0].Messages, 2)
+
+	// 첫 번째 메시지 확인
+	assert.Equal(t, "frank", streams[0].Messages[0].Values["user"])
+	assert.Equal(t, "login", streams[0].Messages[0].Values["action"])
+
+	// 두 번째 메시지 확인
+	assert.Equal(t, "angela", streams[0].Messages[1].Values["user"])
+	assert.Equal(t, "purchase", streams[0].Messages[1].Values["action"])
+}
+
+func Test_Stream_XRange(t *testing.T) {
+	rdb := newStreamClient(t)
+	ctx := context.Background()
+
+	// 메시지 추가
+	for i := 0; i < 5; i++ {
+		rdb.XAdd(ctx, &redis.XAddArgs{
+			Stream: "events",
+			Values: map[string]interface{}{
+				"event_id": i,
+				"type":     "click",
+			},
+		})
+	}
+
+	// XRANGE - 범위 조회 (전체)
+	messages, err := rdb.XRange(ctx, "events", "-", "+").Result()
+	assert.NoError(t, err)
+	assert.Len(t, messages, 5)
+
+	// XREVRANGE - 역순 조회 (최신 2개)
+	latest, err := rdb.XRevRangeN(ctx, "events", "+", "-", 2).Result()
+	assert.NoError(t, err)
+	assert.Len(t, latest, 2)
+
+	// XLEN - 스트림 길이
+	length, err := rdb.XLen(ctx, "events").Result()
+	assert.NoError(t, err)
+	assert.Equal(t, int64(5), length)
+}
+
+func Test_Stream_ConsumerGroup(t *testing.T) {
+	rdb := newStreamClient(t)
+	ctx := context.Background()
+
+	stream := "orders"
+	group := "order-processors"
+
+	// 메시지 추가
+	rdb.XAdd(ctx, &redis.XAddArgs{
+		Stream: stream,
+		Values: map[string]interface{}{"order_id": "1001", "item": "laptop"},
+	})
+	rdb.XAdd(ctx, &redis.XAddArgs{
+		Stream: stream,
+		Values: map[string]interface{}{"order_id": "1002", "item": "phone"},
+	})
+	rdb.XAdd(ctx, &redis.XAddArgs{
+		Stream: stream,
+		Values: map[string]interface{}{"order_id": "1003", "item": "tablet"},
+	})
+
+	// Consumer Group 생성 (스트림 처음부터 읽기)
+	err := rdb.XGroupCreate(ctx, stream, group, "0").Err()
+	assert.NoError(t, err)
+
+	// Consumer 1: 메시지 읽기
+	result1, err := rdb.XReadGroup(ctx, &redis.XReadGroupArgs{
+		Group:    group,
+		Consumer: "consumer-1",
+		Streams:  []string{stream, ">"},
+		Count:    2,
+	}).Result()
+	assert.NoError(t, err)
+	assert.Len(t, result1[0].Messages, 2)
+	assert.Equal(t, "1001", result1[0].Messages[0].Values["order_id"])
+	assert.Equal(t, "1002", result1[0].Messages[1].Values["order_id"])
+
+	// Consumer 2: 남은 메시지 읽기
+	result2, err := rdb.XReadGroup(ctx, &redis.XReadGroupArgs{
+		Group:    group,
+		Consumer: "consumer-2",
+		Streams:  []string{stream, ">"},
+		Count:    2,
+	}).Result()
+	assert.NoError(t, err)
+	assert.Len(t, result2[0].Messages, 1)
+	assert.Equal(t, "1003", result2[0].Messages[0].Values["order_id"])
+
+	// XACK - 메시지 처리 완료 확인
+	ackCount, err := rdb.XAck(ctx, stream, group,
+		result1[0].Messages[0].ID,
+		result1[0].Messages[1].ID,
+	).Result()
+	assert.NoError(t, err)
+	assert.Equal(t, int64(2), ackCount)
+
+	// XPENDING - 미처리 메시지 확인 (consumer-2의 1건)
+	pending, err := rdb.XPending(ctx, stream, group).Result()
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), pending.Count)
+}


### PR DESCRIPTION
## Summary
- Redis Pub/Sub 테스트 추가 (기본 발행/구독, 패턴 구독, 다중 채널)
- Redis Stream 테스트 추가 (XADD/XREAD, XRange, Consumer Group)
- miniredis 테스트 추가 (기본 Set/Get, TTL FastForward, Sorted Set, Pub/Sub)
- 기존 redis_test.go import 경로 수정
- 전체 10개 테스트 PASS (Docker 불필요, miniredis 기반)

## Test plan
- [x] `go test -v -run "Test_PubSub" ./database/redis/redis/` 통과
- [x] `go test -v -run "Test_Stream" ./database/redis/redis/` 통과
- [x] `go test -v -run "Test_Miniredis" ./database/redis/redis/` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)