### PR TITLE
feat: reflect 벤치마크 코드 추가 및 기존 테스트 수정

### DIFF
--- a/golang/reflect/benchmark_test.go
+++ b/golang/reflect/benchmark_test.go
@@ -1,0 +1,85 @@
+package go_reflect
+
+import (
+	"reflect"
+	"testing"
+)
+
+type BenchStruct struct {
+	Name string
+	Age  int
+}
+
+func (b BenchStruct) GetName() string {
+	return b.Name
+}
+
+// 필드 읽기: 직접 접근 vs reflect
+func BenchmarkFieldDirect(b *testing.B) {
+	s := BenchStruct{Name: "Go", Age: 10}
+	var name string
+	for i := 0; i < b.N; i++ {
+		name = s.Name
+	}
+	_ = name
+}
+
+func BenchmarkFieldReflect(b *testing.B) {
+	s := BenchStruct{Name: "Go", Age: 10}
+	v := reflect.ValueOf(s)
+	var name string
+	for i := 0; i < b.N; i++ {
+		name = v.Field(0).String()
+	}
+	_ = name
+}
+
+// 메서드 호출: 직접 호출 vs reflect
+func BenchmarkMethodDirect(b *testing.B) {
+	s := BenchStruct{Name: "Go", Age: 10}
+	var name string
+	for i := 0; i < b.N; i++ {
+		name = s.GetName()
+	}
+	_ = name
+}
+
+func BenchmarkMethodReflect(b *testing.B) {
+	s := BenchStruct{Name: "Go", Age: 10}
+	v := reflect.ValueOf(s)
+	method := v.MethodByName("GetName")
+	for i := 0; i < b.N; i++ {
+		method.Call(nil)
+	}
+}
+
+// 구조체 생성: 리터럴 vs reflect.New
+func BenchmarkCreateDirect(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = BenchStruct{Name: "Go", Age: 10}
+	}
+}
+
+func BenchmarkCreateReflect(b *testing.B) {
+	t := reflect.TypeOf(BenchStruct{})
+	for i := 0; i < b.N; i++ {
+		_ = reflect.New(t).Elem()
+	}
+}
+
+// DeepEqual vs 직접 비교
+func BenchmarkEqualDirect(b *testing.B) {
+	s1 := BenchStruct{Name: "Go", Age: 10}
+	s2 := BenchStruct{Name: "Go", Age: 10}
+	for i := 0; i < b.N; i++ {
+		_ = s1.Name == s2.Name && s1.Age == s2.Age
+	}
+}
+
+func BenchmarkEqualDeepEqual(b *testing.B) {
+	s1 := BenchStruct{Name: "Go", Age: 10}
+	s2 := BenchStruct{Name: "Go", Age: 10}
+	for i := 0; i < b.N; i++ {
+		reflect.DeepEqual(s1, s2)
+	}
+}

--- a/golang/reflect/reflect_test.go
+++ b/golang/reflect/reflect_test.go
@@ -5,15 +5,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"strings"
 	"testing"
 
-	"github.com/kenshin579/tutorials-go/go-reflect/model"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+
+	"github.com/kenshin579/tutorials-go/golang/reflect/model"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/guregu/null.v4"
 )
 
-func Example_Type_Value_정보_확인() {
+func Example_typeValueInfo() {
 	type Foo struct {
 		x int
 		y float64
@@ -38,7 +40,7 @@ func Example_Type_Value_정보_확인() {
 	// z: str(string)
 }
 
-func Example_Struct_Type_Value_메타_정보_확인() {
+func Example_structTypeValueMeta() {
 	type ArticleRequest struct {
 		Title string `json:"title" validate:"required"`
 		Body  string `json:"body" validate:"required"`
@@ -62,7 +64,7 @@ func Example_Struct_Type_Value_메타_정보_확인() {
 	// string Body json:"body" validate:"required"
 }
 
-func Example_Value_변경() {
+func Example_valueModify() {
 	languages := []string{"golang", "java", "c++"}
 	sliceValue := reflect.ValueOf(languages)
 	value := sliceValue.Index(1)
@@ -88,7 +90,7 @@ func Example_Value_변경() {
 
 }
 
-func Example_Method_동적_호출() {
+func Example_methodDynamicCall() {
 	caption := "go is an open source programming language"
 	// 1. TitleCase를 바로 호출
 	title := TitleCase(caption)
@@ -106,10 +108,10 @@ func Example_Method_동적_호출() {
 }
 
 func TitleCase(s string) string {
-	return strings.Title(s)
+	return cases.Title(language.English).String(s)
 }
 
-func Example_Len() {
+func Example_dynamicLen() {
 	list1 := list.New() // list1.Len() == 0
 	list2 := list.New()
 	list2.PushFront(0.5) // list2.Len() == 1
@@ -138,7 +140,7 @@ func Len(x interface{}) int {
 	panic(fmt.Sprintf("'%v' does not have a length", x))
 }
 
-func Example_구조체_필드_순회하기() {
+func Example_iterateStructFields() {
 	cat := &model.Cat{
 		Name:  "nabi",
 		Age:   5,


### PR DESCRIPTION
## Summary
- `benchmark_test.go` 신규 작성 (필드 읽기/메서드 호출/구조체 생성/DeepEqual 벤치마크)
- Example 함수명 한글 → ASCII 변경 (Go 1.24+ 호환)
- `strings.Title` → `cases.Title` 마이그레이션 (deprecated 함수 대체)

Closes #666

## Test plan
- [x] `go test ./golang/reflect/...` 통과
- [x] `go test -bench=. -benchmem ./golang/reflect/` 벤치마크 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)