### PR TITLE
[#668] Go embed directive 실전 활용 예제 추가

### DIFF
--- a/golang/embed-directive/config/default.yaml
+++ b/golang/embed-directive/config/default.yaml
@@ -1,0 +1,8 @@
+server:
+  port: 8080
+  host: localhost
+
+app:
+  name: my-app
+  version: 1.0.0
+  debug: false

--- a/golang/embed-directive/embed_config_test.go
+++ b/golang/embed-directive/embed_config_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	_ "embed"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+//go:embed config/default.yaml
+var defaultConfig []byte
+
+func loadConfig(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return defaultConfig, nil
+	}
+	return data, nil
+}
+
+func TestEmbed_Config_FallbackToDefault(t *testing.T) {
+	// 존재하지 않는 경로 → 임베디드 기본값 사용
+	data, err := loadConfig("/nonexistent/config.yaml")
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), "port: 8080")
+	assert.Contains(t, string(data), "name: my-app")
+}
+
+func TestEmbed_Config_UseExternalFile(t *testing.T) {
+	// 임시 외부 설정 파일 생성
+	tmpDir := t.TempDir()
+	externalConfig := filepath.Join(tmpDir, "config.yaml")
+	err := os.WriteFile(externalConfig, []byte("server:\n  port: 9090\n"), 0644)
+	assert.NoError(t, err)
+
+	// 외부 파일이 있으면 외부 파일 사용
+	data, err := loadConfig(externalConfig)
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), "port: 9090")
+}

--- a/golang/embed-directive/embed_template_test.go
+++ b/golang/embed-directive/embed_template_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"bytes"
+	"embed"
+	"html/template"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+//go:embed templates/*.html
+var templateFiles embed.FS
+
+func TestEmbed_Template_ParseFS(t *testing.T) {
+	tmpl, err := template.ParseFS(templateFiles, "templates/*.html")
+	assert.NoError(t, err)
+
+	data := struct {
+		Title   string
+		Message string
+	}{
+		Title:   "Hello Embed",
+		Message: "This is rendered from an embedded template.",
+	}
+
+	var buf bytes.Buffer
+	err = tmpl.ExecuteTemplate(&buf, "index.html", data)
+	assert.NoError(t, err)
+
+	result := buf.String()
+	assert.Contains(t, result, "Hello Embed")
+	assert.Contains(t, result, "This is rendered from an embedded template.")
+}

--- a/golang/embed-directive/embed_webserver_test.go
+++ b/golang/embed-directive/embed_webserver_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"embed"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+//go:embed static/*
+var staticFiles embed.FS
+
+func TestEmbed_FileServer_ServesHTML(t *testing.T) {
+	subFS, err := fs.Sub(staticFiles, "static")
+	assert.NoError(t, err)
+
+	server := httptest.NewServer(http.FileServer(http.FS(subFS)))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/index.html")
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "text/html")
+}
+
+func TestEmbed_FileServer_ServesCSS(t *testing.T) {
+	subFS, err := fs.Sub(staticFiles, "static")
+	assert.NoError(t, err)
+
+	server := httptest.NewServer(http.FileServer(http.FS(subFS)))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/style.css")
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "text/css")
+}
+
+func TestEmbed_FileServer_Returns404ForMissing(t *testing.T) {
+	subFS, err := fs.Sub(staticFiles, "static")
+	assert.NoError(t, err)
+
+	server := httptest.NewServer(http.FileServer(http.FS(subFS)))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/notfound.html")
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}

--- a/golang/embed-directive/static/index.html
+++ b/golang/embed-directive/static/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Embedded Static Site</title>
+    <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+    <h1>Hello from Embedded Static Files!</h1>
+    <p>This page is served from an embedded file system.</p>
+</body>
+</html>

--- a/golang/embed-directive/static/style.css
+++ b/golang/embed-directive/static/style.css
@@ -1,0 +1,10 @@
+body {
+    font-family: sans-serif;
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 2rem;
+}
+
+h1 {
+    color: #2563eb;
+}

--- a/golang/embed-directive/templates/index.html
+++ b/golang/embed-directive/templates/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{.Title}}</title>
+</head>
+<body>
+    <h1>{{.Title}}</h1>
+    <p>{{.Message}}</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- `embed.FS` + `http.FileServer` 조합 웹 서버 예제 추가
- `template.ParseFS()` HTML 템플릿 임베딩 예제 추가
- 설정 파일 기본값 fallback 패턴 예제 추가
- 리소스 파일: `static/`, `templates/`, `config/` 디렉토리

## Test plan
- [x] `go test -v ./golang/embed-directive/...` 전체 10개 테스트 PASS

## 참조
- 블로그 PR: kenshin579/blog-v2.advenoh.pe.kr#312

🤖 Generated with [Claude Code](https://claude.com/claude-code)