### PR TITLE
feat: Go Rate Limiting 및 Retry 패턴 샘플 코드

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -93,7 +93,9 @@ require (
 	github.com/antchfx/htmlquery v1.3.0 // indirect
 	github.com/antchfx/xmlquery v1.3.15 // indirect
 	github.com/antchfx/xpath v1.2.3 // indirect
+	github.com/avast/retry-go/v4 v4.7.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.2 // indirect
+	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chromedp/sysutil v1.0.0 // indirect
 	github.com/containerd/cgroups v1.0.1 // indirect
@@ -109,6 +111,7 @@ require (
 	github.com/eapache/queue v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/gdamore/encoding v1.0.0 // indirect
+	github.com/go-redis/redis_rate/v10 v10.0.1 // indirect
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gobwas/httphead v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,8 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
+github.com/avast/retry-go/v4 v4.7.0 h1:yjDs35SlGvKwRNSykujfjdMxMhMQQM0TnIjJaHB+Zio=
+github.com/avast/retry-go/v4 v4.7.0/go.mod h1:ZMPDa3sY2bKgpLtap9JRUgk2yTAba7cgiFhqxY2Sg6Q=
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/benweissmann/memongo v0.1.1 h1:L8pux/nWAmb6Zp+83vzqeW4+8GzzRIUBUhHMQizhX/M=
 github.com/benweissmann/memongo v0.1.1/go.mod h1:qMwr8bSVXCD9pUHgkcM3Nc8PZlzZy8UxNWteDDW/rw0=
@@ -146,6 +148,8 @@ github.com/bxcodec/faker v2.0.1+incompatible/go.mod h1:BNzfpVdTwnFJ6GtfYTcQu6l6r
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/backoff/v4 v4.1.2 h1:6Yo7N8UP2K6LWZnW94DLVSSrbobcWdVzAYOisuDPIFo=
 github.com/cenkalti/backoff/v4 v4.1.2/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
+github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
+github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -390,6 +394,8 @@ github.com/go-redis/redis/v8 v8.11.4 h1:kHoYkfZP6+pe04aFTnhDH6GDROa5yJdHJVNxV3F4
 github.com/go-redis/redis/v8 v8.11.4/go.mod h1:2Z2wHZXdQpCDXEGzqMockDpNyYvi2l4Pxt6RJr792+w=
 github.com/go-redis/redis/v9 v9.0.0-beta.2 h1:ZSr84TsnQyKMAg8gnV+oawuQezeJR11/09THcWCQzr4=
 github.com/go-redis/redis/v9 v9.0.0-beta.2/go.mod h1:Bldcd/M/bm9HbnNPi/LUtYBSD8ttcZYBMupwMXhdU0o=
+github.com/go-redis/redis_rate/v10 v10.0.1 h1:calPxi7tVlxojKunJwQ72kwfozdy25RjA0bCj1h0MUo=
+github.com/go-redis/redis_rate/v10 v10.0.1/go.mod h1:EMiuO9+cjRkR7UvdvwMO7vbgqJkltQHtwbdIQvaBKIU=
 github.com/go-redsync/redsync/v4 v4.5.1 h1:T97UCaY8MfQg/6kB7MTuimF4tnLOCdJbsvIoN5KmjZE=
 github.com/go-redsync/redsync/v4 v4.5.1/go.mod h1:AfhgO1E6W3rlUTs6Zmz/B6qBZJFasV30lwo7nlizdDs=
 github.com/go-resty/resty/v2 v2.7.0 h1:me+K9p3uhSmXtrBZ4k9jcEAfJmuC8IivWHwaLZwPrFY=

--- a/golang/resilience/README.md
+++ b/golang/resilience/README.md
@@ -1,0 +1,35 @@
+# Resilience Patterns in Go
+
+Rate Limiting과 Retry 패턴 예제 코드.
+
+## 구조
+
+```
+resilience/
+├── ratelimit/
+│   ├── token_bucket.go           # x/time/rate 기반 Token Bucket
+│   ├── token_bucket_test.go
+│   ├── middleware.go             # Echo HTTP 미들웨어 (IP별 Rate Limiting)
+│   ├── middleware_test.go
+│   ├── redis_limiter.go          # go-redis/redis_rate 분산 Rate Limiting
+│   └── redis_limiter_test.go     # testcontainers-go 통합 테스트
+├── retry/
+│   ├── backoff.go                # cenkalti/backoff/v5 Exponential Backoff
+│   ├── backoff_test.go
+│   ├── retry.go                  # avast/retry-go/v4 Jitter Retry
+│   └── retry_test.go
+└── README.md
+```
+
+## 테스트
+
+```bash
+# 단위 테스트만 실행
+go test -short ./golang/resilience/...
+
+# 전체 테스트 (Docker 필요 - Redis 통합 테스트 포함)
+go test ./golang/resilience/...
+```
+
+## 관련 블로그
+- [Go Rate Limiting 완벽 가이드](https://blog-v2.advenoh.pe.kr)

--- a/golang/resilience/ratelimit/middleware.go
+++ b/golang/resilience/ratelimit/middleware.go
@@ -1,0 +1,42 @@
+package ratelimit
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+	"golang.org/x/time/rate"
+)
+
+// RateLimitConfig defines the config for rate limit middleware.
+type RateLimitConfig struct {
+	Rate    rate.Limit
+	Burst   int
+	Skipper middleware.Skipper
+}
+
+// RateLimitMiddleware returns Echo middleware that limits requests per IP.
+func RateLimitMiddleware(config RateLimitConfig) echo.MiddlewareFunc {
+	var clients sync.Map
+
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			if config.Skipper != nil && config.Skipper(c) {
+				return next(c)
+			}
+
+			ip := c.RealIP()
+			v, _ := clients.LoadOrStore(ip, rate.NewLimiter(config.Rate, config.Burst))
+			limiter := v.(*rate.Limiter)
+
+			if !limiter.Allow() {
+				return c.JSON(http.StatusTooManyRequests, map[string]string{
+					"error": "rate limit exceeded",
+				})
+			}
+
+			return next(c)
+		}
+	}
+}

--- a/golang/resilience/ratelimit/middleware_test.go
+++ b/golang/resilience/ratelimit/middleware_test.go
@@ -1,0 +1,92 @@
+package ratelimit
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
+)
+
+func setupEcho(config RateLimitConfig) *echo.Echo {
+	e := echo.New()
+	e.Use(RateLimitMiddleware(config))
+	e.GET("/test", func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+	return e
+}
+
+func TestMiddleware_AllowNormalRequests(t *testing.T) {
+	e := setupEcho(RateLimitConfig{Rate: rate.Limit(10), Burst: 5})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestMiddleware_RejectExcessRequests(t *testing.T) {
+	e := setupEcho(RateLimitConfig{Rate: rate.Limit(1), Burst: 2})
+
+	// Burst 2개 허용
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code)
+	}
+
+	// 3번째 요청은 429
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusTooManyRequests, rec.Code)
+}
+
+func TestMiddleware_PerIPIsolation(t *testing.T) {
+	e := setupEcho(RateLimitConfig{Rate: rate.Limit(1), Burst: 1})
+
+	// IP1: 첫 요청 허용
+	req1 := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req1.Header.Set("X-Real-Ip", "1.1.1.1")
+	rec1 := httptest.NewRecorder()
+	e.ServeHTTP(rec1, req1)
+	assert.Equal(t, http.StatusOK, rec1.Code)
+
+	// IP1: 두 번째 요청 거부
+	req2 := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req2.Header.Set("X-Real-Ip", "1.1.1.1")
+	rec2 := httptest.NewRecorder()
+	e.ServeHTTP(rec2, req2)
+	assert.Equal(t, http.StatusTooManyRequests, rec2.Code)
+
+	// IP2: 다른 IP는 허용
+	req3 := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req3.Header.Set("X-Real-Ip", "2.2.2.2")
+	rec3 := httptest.NewRecorder()
+	e.ServeHTTP(rec3, req3)
+	assert.Equal(t, http.StatusOK, rec3.Code)
+}
+
+func TestMiddleware_Skipper(t *testing.T) {
+	e := setupEcho(RateLimitConfig{
+		Rate:  rate.Limit(1),
+		Burst: 1,
+		Skipper: func(c echo.Context) bool {
+			return c.Path() == "/test"
+		},
+	})
+
+	// Skipper가 true이면 rate limit 무시
+	for i := 0; i < 5; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Code)
+	}
+}

--- a/golang/resilience/ratelimit/redis_limiter.go
+++ b/golang/resilience/ratelimit/redis_limiter.go
@@ -1,0 +1,25 @@
+package ratelimit
+
+import (
+	"context"
+
+	"github.com/go-redis/redis_rate/v10"
+	"github.com/redis/go-redis/v9"
+)
+
+// DistributedRateLimiter provides Redis-based distributed rate limiting using GCRA algorithm.
+type DistributedRateLimiter struct {
+	limiter *redis_rate.Limiter
+}
+
+// NewDistributedRateLimiter creates a new distributed rate limiter backed by Redis.
+func NewDistributedRateLimiter(rdb *redis.Client) *DistributedRateLimiter {
+	return &DistributedRateLimiter{
+		limiter: redis_rate.NewLimiter(rdb),
+	}
+}
+
+// Allow checks whether a request identified by key is allowed under the given limit.
+func (d *DistributedRateLimiter) Allow(ctx context.Context, key string, limit redis_rate.Limit) (*redis_rate.Result, error) {
+	return d.limiter.Allow(ctx, key, limit)
+}

--- a/golang/resilience/ratelimit/redis_limiter_test.go
+++ b/golang/resilience/ratelimit/redis_limiter_test.go
@@ -1,0 +1,127 @@
+package ratelimit
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-redis/redis_rate/v10"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+func setupRedis(t *testing.T) (*redis.Client, func()) {
+	t.Helper()
+	ctx := context.Background()
+
+	req := testcontainers.ContainerRequest{
+		Image:        "redis:7-alpine",
+		ExposedPorts: []string{"6379/tcp"},
+		WaitingFor:   wait.ForLog("Ready to accept connections"),
+	}
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	require.NoError(t, err)
+
+	endpoint, err := container.Endpoint(ctx, "")
+	require.NoError(t, err)
+
+	rdb := redis.NewClient(&redis.Options{Addr: endpoint})
+	require.NoError(t, rdb.Ping(ctx).Err())
+
+	cleanup := func() {
+		rdb.Close()
+		container.Terminate(ctx)
+	}
+	return rdb, cleanup
+}
+
+func TestDistributedRateLimiter_AllowAndDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	rdb, cleanup := setupRedis(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	limiter := NewDistributedRateLimiter(rdb)
+	limit := redis_rate.PerSecond(2)
+
+	// 첫 2개 요청 허용
+	for i := 0; i < 2; i++ {
+		result, err := limiter.Allow(ctx, "test:user1", limit)
+		require.NoError(t, err)
+		assert.True(t, result.Allowed > 0, "request %d should be allowed", i+1)
+	}
+
+	// 초과 요청 거부
+	result, err := limiter.Allow(ctx, "test:user1", limit)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.Allowed, "excess request should be denied")
+	assert.True(t, result.RetryAfter > 0, "should have retry-after")
+}
+
+func TestDistributedRateLimiter_DifferentKeys(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	rdb, cleanup := setupRedis(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	limiter := NewDistributedRateLimiter(rdb)
+	limit := redis_rate.PerSecond(1)
+
+	// user1 요청
+	r1, err := limiter.Allow(ctx, "test:user1", limit)
+	require.NoError(t, err)
+	assert.True(t, r1.Allowed > 0)
+
+	// user1 초과
+	r2, err := limiter.Allow(ctx, "test:user1", limit)
+	require.NoError(t, err)
+	assert.Equal(t, 0, r2.Allowed)
+
+	// user2는 별도 키이므로 허용
+	r3, err := limiter.Allow(ctx, "test:user2", limit)
+	require.NoError(t, err)
+	assert.True(t, r3.Allowed > 0)
+}
+
+func TestDistributedRateLimiter_MultipleClients(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	rdb, cleanup := setupRedis(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	limiter1 := NewDistributedRateLimiter(rdb)
+	limiter2 := NewDistributedRateLimiter(rdb)
+
+	limit := redis_rate.Limit{
+		Rate:   2,
+		Burst:  2,
+		Period: time.Second,
+	}
+
+	// 클라이언트1에서 2개 요청
+	for i := 0; i < 2; i++ {
+		r, err := limiter1.Allow(ctx, "shared:key", limit)
+		require.NoError(t, err)
+		assert.True(t, r.Allowed > 0)
+	}
+
+	// 클라이언트2에서 같은 키 요청 → 거부 (공유 카운터)
+	r, err := limiter2.Allow(ctx, "shared:key", limit)
+	require.NoError(t, err)
+	assert.Equal(t, 0, r.Allowed, "shared counter should reject from second client")
+}

--- a/golang/resilience/ratelimit/token_bucket.go
+++ b/golang/resilience/ratelimit/token_bucket.go
@@ -1,0 +1,33 @@
+package ratelimit
+
+import (
+	"context"
+
+	"golang.org/x/time/rate"
+)
+
+// RateLimiter wraps x/time/rate.Limiter providing three usage patterns.
+type RateLimiter struct {
+	limiter *rate.Limiter
+}
+
+// NewRateLimiter creates a new RateLimiter.
+// r is the rate of tokens per second, burst is the maximum burst size.
+func NewRateLimiter(r rate.Limit, burst int) *RateLimiter {
+	return &RateLimiter{limiter: rate.NewLimiter(r, burst)}
+}
+
+// Allow reports whether an event may happen now (non-blocking).
+func (rl *RateLimiter) Allow() bool {
+	return rl.limiter.Allow()
+}
+
+// Wait blocks until the limiter permits an event or ctx is done.
+func (rl *RateLimiter) Wait(ctx context.Context) error {
+	return rl.limiter.Wait(ctx)
+}
+
+// Reserve returns a Reservation that indicates how long the caller must wait.
+func (rl *RateLimiter) Reserve() *rate.Reservation {
+	return rl.limiter.Reserve()
+}

--- a/golang/resilience/ratelimit/token_bucket_test.go
+++ b/golang/resilience/ratelimit/token_bucket_test.go
@@ -1,0 +1,93 @@
+package ratelimit
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
+)
+
+func TestRateLimiter_Allow(t *testing.T) {
+	// 1 token/sec, burst 3
+	rl := NewRateLimiter(rate.Limit(1), 3)
+
+	// Burst 3개까지는 즉시 허용
+	assert.True(t, rl.Allow())
+	assert.True(t, rl.Allow())
+	assert.True(t, rl.Allow())
+
+	// Burst 소진 후 거부
+	assert.False(t, rl.Allow())
+}
+
+func TestRateLimiter_Wait(t *testing.T) {
+	// 10 tokens/sec, burst 1
+	rl := NewRateLimiter(rate.Limit(10), 1)
+
+	// 첫 번째는 즉시 허용
+	ctx := context.Background()
+	require.NoError(t, rl.Wait(ctx))
+
+	// 두 번째는 대기 후 허용 (약 100ms)
+	start := time.Now()
+	require.NoError(t, rl.Wait(ctx))
+	elapsed := time.Since(start)
+	assert.True(t, elapsed >= 50*time.Millisecond, "should wait for token replenishment")
+}
+
+func TestRateLimiter_Wait_ContextCancel(t *testing.T) {
+	// 매우 느린 rate
+	rl := NewRateLimiter(rate.Limit(0.1), 1)
+
+	// Burst 소진
+	rl.Allow()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := rl.Wait(ctx)
+	assert.Error(t, err, "should fail when context is cancelled")
+}
+
+func TestRateLimiter_Reserve(t *testing.T) {
+	rl := NewRateLimiter(rate.Limit(10), 1)
+
+	// 첫 번째 예약은 즉시
+	r1 := rl.Reserve()
+	assert.True(t, r1.OK())
+	assert.Zero(t, r1.Delay())
+
+	// 두 번째 예약은 대기 필요
+	r2 := rl.Reserve()
+	assert.True(t, r2.OK())
+	assert.True(t, r2.Delay() > 0)
+}
+
+func TestRateLimiter_Concurrency(t *testing.T) {
+	// 100 tokens/sec, burst 10
+	rl := NewRateLimiter(rate.Limit(100), 10)
+
+	var allowed atomic.Int64
+	done := make(chan struct{})
+
+	for i := 0; i < 50; i++ {
+		go func() {
+			if rl.Allow() {
+				allowed.Add(1)
+			}
+			done <- struct{}{}
+		}()
+	}
+
+	for i := 0; i < 50; i++ {
+		<-done
+	}
+
+	// Burst 10이므로 최대 10개 허용
+	assert.True(t, allowed.Load() <= 10, "should not exceed burst size")
+	assert.True(t, allowed.Load() > 0, "should allow some requests")
+}

--- a/golang/resilience/retry/backoff.go
+++ b/golang/resilience/retry/backoff.go
@@ -1,0 +1,20 @@
+package retry
+
+import (
+	"context"
+	"time"
+
+	"github.com/cenkalti/backoff/v5"
+)
+
+// RetryWithExponentialBackoff retries the operation using exponential backoff.
+// It stops retrying when maxElapsed time passes or the context is cancelled.
+func RetryWithExponentialBackoff(ctx context.Context, operation func() error, maxElapsed time.Duration) error {
+	_, err := backoff.Retry(ctx, func() (struct{}, error) {
+		return struct{}{}, operation()
+	},
+		backoff.WithBackOff(backoff.NewExponentialBackOff()),
+		backoff.WithMaxElapsedTime(maxElapsed),
+	)
+	return err
+}

--- a/golang/resilience/retry/backoff_test.go
+++ b/golang/resilience/retry/backoff_test.go
@@ -1,0 +1,47 @@
+package retry
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var errTransient = errors.New("transient error")
+
+func TestRetryWithExponentialBackoff_Success(t *testing.T) {
+	var attempts atomic.Int32
+
+	err := RetryWithExponentialBackoff(context.Background(), func() error {
+		if attempts.Add(1) < 3 {
+			return errTransient
+		}
+		return nil
+	}, 5*time.Second)
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(3), attempts.Load())
+}
+
+func TestRetryWithExponentialBackoff_MaxElapsed(t *testing.T) {
+	err := RetryWithExponentialBackoff(context.Background(), func() error {
+		return errTransient
+	}, 500*time.Millisecond)
+
+	assert.Error(t, err, "should fail after max elapsed time")
+}
+
+func TestRetryWithExponentialBackoff_ContextCancel(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	err := RetryWithExponentialBackoff(ctx, func() error {
+		return errTransient
+	}, 10*time.Second)
+
+	assert.Error(t, err, "should fail when context is cancelled")
+}

--- a/golang/resilience/retry/retry.go
+++ b/golang/resilience/retry/retry.go
@@ -1,0 +1,19 @@
+package retry
+
+import (
+	"context"
+	"time"
+
+	retryx "github.com/avast/retry-go/v4"
+)
+
+// RetryWithJitter retries fn with exponential backoff and jitter.
+func RetryWithJitter(ctx context.Context, fn retryx.RetryableFunc, maxAttempts uint, opts ...retryx.Option) error {
+	defaultOpts := []retryx.Option{
+		retryx.Attempts(maxAttempts),
+		retryx.DelayType(retryx.BackOffDelay),
+		retryx.Context(ctx),
+		retryx.MaxJitter(1 * time.Second),
+	}
+	return retryx.Do(fn, append(defaultOpts, opts...)...)
+}

--- a/golang/resilience/retry/retry_test.go
+++ b/golang/resilience/retry/retry_test.go
@@ -1,0 +1,86 @@
+package retry
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	retryx "github.com/avast/retry-go/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var errRetryable = errors.New("retryable error")
+var errPermanent = errors.New("permanent error")
+
+func TestRetryWithJitter_Success(t *testing.T) {
+	var attempts atomic.Int32
+
+	err := RetryWithJitter(context.Background(), func() error {
+		if attempts.Add(1) < 3 {
+			return errRetryable
+		}
+		return nil
+	}, 5)
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(3), attempts.Load())
+}
+
+func TestRetryWithJitter_MaxAttempts(t *testing.T) {
+	var attempts atomic.Int32
+
+	err := RetryWithJitter(context.Background(), func() error {
+		attempts.Add(1)
+		return errRetryable
+	}, 3, retryx.Delay(10*time.Millisecond))
+
+	assert.Error(t, err, "should fail after max attempts")
+	assert.Equal(t, int32(3), attempts.Load())
+}
+
+func TestRetryWithJitter_RetryIf(t *testing.T) {
+	var attempts atomic.Int32
+
+	err := RetryWithJitter(context.Background(), func() error {
+		attempts.Add(1)
+		return errPermanent
+	}, 5,
+		retryx.Delay(10*time.Millisecond),
+		retryx.RetryIf(func(err error) bool {
+			return !errors.Is(err, errPermanent)
+		}),
+	)
+
+	assert.Error(t, err, "should not retry permanent errors")
+	assert.Equal(t, int32(1), attempts.Load(), "should stop after first attempt")
+}
+
+func TestRetryWithJitter_OnRetry(t *testing.T) {
+	var retryCount atomic.Int32
+
+	err := RetryWithJitter(context.Background(), func() error {
+		return errRetryable
+	}, 3,
+		retryx.Delay(10*time.Millisecond),
+		retryx.OnRetry(func(n uint, err error) {
+			retryCount.Add(1)
+		}),
+	)
+
+	assert.Error(t, err)
+	assert.Equal(t, int32(3), retryCount.Load(), "OnRetry should be called for each failed attempt")
+}
+
+func TestRetryWithJitter_ContextCancel(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := RetryWithJitter(ctx, func() error {
+		return errRetryable
+	}, 100, retryx.Delay(50*time.Millisecond))
+
+	assert.Error(t, err, "should fail when context is cancelled")
+}


### PR DESCRIPTION
## Summary
- `golang/resilience/ratelimit/` - Token Bucket (x/time/rate), Echo HTTP 미들웨어, Redis 분산 Rate Limiting (go-redis/redis_rate)
- `golang/resilience/retry/` - Exponential Backoff (cenkalti/backoff/v5), Jitter Retry (avast/retry-go/v4)
- 단위 테스트 + testcontainers-go Redis 통합 테스트

## Test plan
- [x] `go test -short ./golang/resilience/...` 전체 통과
- [x] `go vet ./golang/resilience/...` 통과
- [x] Redis 통합 테스트 (`DOCKER_API_VERSION=1.44 go test ./golang/resilience/ratelimit/ -run TestDistributed`) 통과

Closes #676

🤖 Generated with [Claude Code](https://claude.com/claude-code)