### PR TITLE
fix: Wails Todo 삭제 다이얼로그 버튼 명시적 지정

### DIFF
--- a/desktop/wails-todo/backend/app.go
+++ b/desktop/wails-todo/backend/app.go
@@ -60,7 +60,9 @@ func (a *App) DeleteTodo(id string) []Todo {
 				Type:          runtime.QuestionDialog,
 				Title:         "삭제 확인",
 				Message:       fmt.Sprintf("'%s'을(를) 삭제하시겠습니까?", t.Title),
+				Buttons:       []string{"Yes", "No"},
 				DefaultButton: "No",
+				CancelButton:  "No",
 			})
 			if err == nil && result == "Yes" {
 				a.store.Todos = append(a.store.Todos[:i], a.store.Todos[i+1:]...)


### PR DESCRIPTION
## Summary
- macOS에서 `MessageDialog`의 `Buttons` 필드를 지정하지 않으면 기본 버튼이 OK/Cancel로 표시되어 반환값이 `"OK"`가 됨
- 코드에서 `result == "Yes"`로 비교하고 있어 삭제가 항상 실패하는 버그 수정
- `Buttons: []string{"Yes", "No"}`를 명시적으로 지정하여 반환값이 `"Yes"`가 되도록 수정

## Test plan
- [ ] Wails Todo 앱에서 할 일 삭제 버튼 클릭 시 확인 다이얼로그가 표시되는지 확인
- [ ] "Yes" 클릭 시 정상적으로 삭제되는지 확인
- [ ] "No" 클릭 시 삭제되지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)