### PR TITLE
feat: superpowers todo app (학습 샘플)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,6 +261,5 @@ Viper is the standard for configuration:
 
 ## Language Version
 
-- **Go Version**: 1.21.3 minimum (specified in go.mod)
-- **Toolchain**: go1.22.3
-- Some examples may use features from Go 1.18+ (generics, workspaces)
+- **Go Version**: 1.26.0 (specified in go.mod)
+- Some examples may use features from Go 1.18+ (generics, workspaces, `http.ServeMux` 향상된 라우팅 등)

--- a/ai/superpowers/todo/.gitignore
+++ b/ai/superpowers/todo/.gitignore
@@ -1,0 +1,8 @@
+# frontend
+frontend/node_modules/
+frontend/dist/
+frontend/coverage/
+
+# misc
+.DS_Store
+*.log

--- a/ai/superpowers/todo/.gitignore
+++ b/ai/superpowers/todo/.gitignore
@@ -2,6 +2,9 @@
 frontend/node_modules/
 frontend/dist/
 frontend/coverage/
+frontend/*.tsbuildinfo
+frontend/vite.config.d.ts
+frontend/vite.config.js
 
 # misc
 .DS_Store

--- a/ai/superpowers/todo/.gitignore
+++ b/ai/superpowers/todo/.gitignore
@@ -6,6 +6,11 @@ frontend/*.tsbuildinfo
 frontend/vite.config.d.ts
 frontend/vite.config.js
 
+# playwright
+frontend/playwright-report/
+frontend/test-results/
+frontend/.playwright/
+
 # misc
 .DS_Store
 *.log

--- a/ai/superpowers/todo/Makefile
+++ b/ai/superpowers/todo/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev-be dev-fe build preview-fe test test-be test-fe install clean
+.PHONY: dev-be dev-fe build preview-fe test test-be test-fe test-e2e install clean
 
 BE_DIR := backend
 FE_DIR := frontend
@@ -26,5 +26,8 @@ test-be:
 test-fe:
 	cd $(FE_DIR) && npm test -- --run
 
+test-e2e:
+	cd $(FE_DIR) && npm run test:e2e
+
 clean:
-	rm -rf $(FE_DIR)/dist $(FE_DIR)/node_modules
+	rm -rf $(FE_DIR)/dist $(FE_DIR)/node_modules $(FE_DIR)/playwright-report $(FE_DIR)/test-results

--- a/ai/superpowers/todo/Makefile
+++ b/ai/superpowers/todo/Makefile
@@ -1,0 +1,30 @@
+.PHONY: dev-be dev-fe build preview-fe test test-be test-fe install clean
+
+BE_DIR := backend
+FE_DIR := frontend
+
+install:
+	cd $(FE_DIR) && npm install
+
+dev-be:
+	cd $(BE_DIR) && go run .
+
+dev-fe:
+	cd $(FE_DIR) && npm run dev
+
+build:
+	cd $(FE_DIR) && npm run build
+
+preview-fe: build
+	cd $(FE_DIR) && npm run preview
+
+test: test-be test-fe
+
+test-be:
+	cd $(BE_DIR) && go test -race ./... && go vet ./...
+
+test-fe:
+	cd $(FE_DIR) && npm test -- --run
+
+clean:
+	rm -rf $(FE_DIR)/dist $(FE_DIR)/node_modules

--- a/ai/superpowers/todo/README.md
+++ b/ai/superpowers/todo/README.md
@@ -21,7 +21,8 @@ make build           # frontend 프로덕션 빌드
 make preview-fe      # 빌드 결과 :4173 프리뷰
 make test            # backend + frontend 테스트
 make test-be         # backend만
-make test-fe         # frontend만
+make test-fe         # frontend 단위 테스트만
+make test-e2e        # Playwright e2e (BE+FE 자동 기동)
 ```
 
 ## 동작 검증
@@ -41,6 +42,17 @@ curl -s -X PATCH -H "Content-Type: application/json" \
 curl -s http://localhost:8080/api/todos
 curl -s -X DELETE -i http://localhost:8080/api/todos/$ID | head -1
 ```
+
+### 자동 e2e 검증 (Playwright)
+
+```bash
+make test-e2e          # 헤드리스로 9개 시나리오 실행
+make test-e2e:ui       # Playwright UI 모드 (디버깅용)
+# 또는 직접:
+cd frontend && npm run test:e2e
+```
+
+`webServer` 옵션이 BE+FE를 자동 기동/정리합니다. 이미 `:8080` 또는 `:5173`이 떠있으면 재사용합니다.
 
 ### Frontend + Backend 통합 검증
 

--- a/ai/superpowers/todo/README.md
+++ b/ai/superpowers/todo/README.md
@@ -24,6 +24,37 @@ make test-be         # backend만
 make test-fe         # frontend만
 ```
 
+## 동작 검증
+
+### Backend 단독 검증
+
+```bash
+make dev-be
+# 다른 터미널에서:
+curl -s http://localhost:8080/api/health
+curl -s -X POST -H "Content-Type: application/json" \
+  -d '{"title":"우유 사기","priority":"high"}' \
+  http://localhost:8080/api/todos | tee /tmp/created.json
+ID=$(cat /tmp/created.json | python3 -c "import sys,json;print(json.load(sys.stdin)['id'])")
+curl -s -X PATCH -H "Content-Type: application/json" \
+  -d '{"completed":true}' http://localhost:8080/api/todos/$ID
+curl -s http://localhost:8080/api/todos
+curl -s -X DELETE -i http://localhost:8080/api/todos/$ID | head -1
+```
+
+### Frontend + Backend 통합 검증
+
+1. 터미널 1: `make dev-be`
+2. 터미널 2: `make dev-fe`
+3. 브라우저로 http://localhost:5173 접속
+4. 시나리오:
+   - 입력 → 추가 → 목록에 등장
+   - 체크박스 토글 → 완료 상태 변화
+   - FilterBar로 필터링/정렬 변경 → 즉시 반영
+   - 제목 클릭 → 편집 → blur로 저장
+   - 삭제 버튼 → 항목 제거
+5. 백엔드 종료 후 새로고침 → "에러" 배너 표시 확인
+
 ## 정책
 
 - **데이터 영속성 없음**: 서버 재시작 시 모든 todo 손실 (in-memory).

--- a/ai/superpowers/todo/README.md
+++ b/ai/superpowers/todo/README.md
@@ -1,0 +1,37 @@
+# Todo Web Application (superpowers 학습용)
+
+Echo (Go) + React (Vite, TypeScript) 기반 in-memory Todo 앱. superpowers plugin skill 사이클을 풀로 체험하기 위한 학습 샘플.
+
+## 실행
+
+```bash
+# Backend (포트 8080)
+make dev-be
+
+# Frontend (포트 5173, /api/* → 8080 proxy)
+make dev-fe
+```
+
+브라우저에서 http://localhost:5173 접속.
+
+## 빌드/테스트
+
+```bash
+make build           # frontend 프로덕션 빌드
+make preview-fe      # 빌드 결과 :4173 프리뷰
+make test            # backend + frontend 테스트
+make test-be         # backend만
+make test-fe         # frontend만
+```
+
+## 정책
+
+- **데이터 영속성 없음**: 서버 재시작 시 모든 todo 손실 (in-memory).
+- **시작 순서**: BE 먼저 띄운 후 FE. BE 부재 시 FE는 에러 배너 표시.
+- **동시 PATCH**: last-write-wins (버전 필드 미도입).
+- **타입 동기화**: `frontend/src/types.ts`는 백엔드 JSON 모델과 수기 동기화. BE 변경 시 같이 수정.
+
+## 문서
+
+- 설계: `docs/superpowers/specs/2026-04-30-todo-app-design.md`
+- 구현 plan: `docs/superpowers/plans/2026-04-30-todo-app-plan.md`

--- a/ai/superpowers/todo/backend/main.go
+++ b/ai/superpowers/todo/backend/main.go
@@ -1,0 +1,18 @@
+// Package main is the entrypoint for the superpowers todo learning sample.
+// It wires the Echo server with an in-memory todo store and starts listening on :8080.
+package main
+
+import (
+	"log"
+
+	"github.com/kenshin579/tutorials-go/ai/superpowers/todo/backend/server"
+	"github.com/kenshin579/tutorials-go/ai/superpowers/todo/backend/todo"
+)
+
+func main() {
+	store := todo.NewStore()
+	srv := server.New(store)
+	if err := srv.Start(":8080"); err != nil {
+		log.Fatalf("server failed: %v", err)
+	}
+}

--- a/ai/superpowers/todo/backend/server/server.go
+++ b/ai/superpowers/todo/backend/server/server.go
@@ -1,0 +1,39 @@
+// Package server wires the Echo HTTP server with middleware and route registration.
+// It is intentionally domain-agnostic — domain logic is in the todo package.
+package server
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+
+	"github.com/kenshin579/tutorials-go/ai/superpowers/todo/backend/todo"
+)
+
+// New constructs a configured *echo.Echo bound to the given store.
+// Middleware order: Recover → Logger → CORS. CORS allows the Vite dev/preview origins.
+func New(store *todo.Store) *echo.Echo {
+	e := echo.New()
+	e.HideBanner = true
+	e.HidePort = true
+
+	e.Use(middleware.Recover())
+	e.Use(middleware.Logger())
+	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
+		AllowOrigins: []string{"http://localhost:5173", "http://localhost:4173"},
+		AllowMethods: []string{http.MethodGet, http.MethodPost, http.MethodPatch, http.MethodDelete, http.MethodOptions},
+	}))
+
+	h := todo.NewHandler(store)
+
+	e.GET("/api/health", func(c echo.Context) error {
+		return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
+	})
+	e.GET("/api/todos", h.List)
+	e.POST("/api/todos", h.Create)
+	e.PATCH("/api/todos/:id", h.Update)
+	e.DELETE("/api/todos/:id", h.Delete)
+
+	return e
+}

--- a/ai/superpowers/todo/backend/server/server_test.go
+++ b/ai/superpowers/todo/backend/server/server_test.go
@@ -1,0 +1,103 @@
+package server_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kenshin579/tutorials-go/ai/superpowers/todo/backend/server"
+	"github.com/kenshin579/tutorials-go/ai/superpowers/todo/backend/todo"
+)
+
+func setupServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	s := todo.NewStore()
+	e := server.New(s)
+	ts := httptest.NewServer(e)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestServer_Health(t *testing.T) {
+	t.Parallel()
+	ts := setupServer(t)
+
+	resp, err := http.Get(ts.URL + "/api/health")
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body map[string]string
+	assert.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, "ok", body["status"])
+}
+
+func TestServer_CRUDLifecycle(t *testing.T) {
+	t.Parallel()
+	ts := setupServer(t)
+
+	// 1. Create
+	create := bytes.NewBufferString(`{"title":"buy milk","priority":"high"}`)
+	resp, err := http.Post(ts.URL+"/api/todos", "application/json", create)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	var created todo.Todo
+	assert.NoError(t, json.NewDecoder(resp.Body).Decode(&created))
+	assert.NotEmpty(t, created.ID)
+	assert.Equal(t, "buy milk", created.Title)
+
+	// 2. List
+	resp, err = http.Get(ts.URL + "/api/todos")
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	var list []todo.Todo
+	assert.NoError(t, json.NewDecoder(resp.Body).Decode(&list))
+	assert.Len(t, list, 1)
+
+	// 3. Update (toggle complete)
+	patch := bytes.NewBufferString(`{"completed":true}`)
+	req, _ := http.NewRequest(http.MethodPatch, ts.URL+"/api/todos/"+created.ID, patch)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = http.DefaultClient.Do(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	var updated todo.Todo
+	assert.NoError(t, json.NewDecoder(resp.Body).Decode(&updated))
+	assert.True(t, updated.Completed)
+
+	// 4. Delete
+	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/api/todos/"+created.ID, nil)
+	resp, err = http.DefaultClient.Do(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	// 5. List again — should be empty
+	resp, err = http.Get(ts.URL + "/api/todos")
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, "[]\n", string(body))
+}
+
+func TestServer_CORSPreflight(t *testing.T) {
+	t.Parallel()
+	ts := setupServer(t)
+
+	req, _ := http.NewRequest(http.MethodOptions, ts.URL+"/api/todos", nil)
+	req.Header.Set("Origin", "http://localhost:5173")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	resp, err := http.DefaultClient.Do(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Contains(t, resp.Header.Get("Access-Control-Allow-Origin"), "http://localhost:5173")
+}

--- a/ai/superpowers/todo/backend/todo/handler.go
+++ b/ai/superpowers/todo/backend/todo/handler.go
@@ -1,6 +1,7 @@
 package todo
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -106,12 +107,98 @@ func parseQuery(c echo.Context) (Query, error) {
 	return q, nil
 }
 
+// Update handles PATCH /api/todos/{id}. The body must be a non-empty JSON object.
+// Only dueDate accepts JSON null (clears the value); other fields with null are rejected.
+func (h *Handler) Update(c echo.Context) error {
+	patch, err := parsePatch(c)
+	if err != nil {
+		return writeError(c, err)
+	}
+	id := c.Param("id")
+	updated, err := h.store.Update(id, patch)
+	if err != nil {
+		return writeError(c, err)
+	}
+	return c.JSON(http.StatusOK, updated)
+}
+
+// parsePatch reads the request body as a partial Todo update.
+// Uses map[string]json.RawMessage for first-pass decoding so we can
+// distinguish "key absent" from "key present with null".
+// Only dueDate accepts JSON null (clears the value).
+func parsePatch(c echo.Context) (Patch, error) {
+	var raw map[string]json.RawMessage
+	if err := json.NewDecoder(c.Request().Body).Decode(&raw); err != nil {
+		return Patch{}, &jsonDecodeError{}
+	}
+
+	patch := Patch{}
+
+	if v, ok := raw["title"]; ok {
+		if isJSONNull(v) {
+			return Patch{}, &ValidationError{Field: "title", Message: "title cannot be null"}
+		}
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return Patch{}, &ValidationError{Field: "title", Message: "title must be a string"}
+		}
+		patch.Title = &s
+	}
+	if v, ok := raw["completed"]; ok {
+		if isJSONNull(v) {
+			return Patch{}, &ValidationError{Field: "completed", Message: "completed cannot be null"}
+		}
+		var b bool
+		if err := json.Unmarshal(v, &b); err != nil {
+			return Patch{}, &ValidationError{Field: "completed", Message: "completed must be a boolean"}
+		}
+		patch.Completed = &b
+	}
+	if v, ok := raw["priority"]; ok {
+		if isJSONNull(v) {
+			return Patch{}, &ValidationError{Field: "priority", Message: "priority cannot be null"}
+		}
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return Patch{}, &ValidationError{Field: "priority", Message: "priority must be a string"}
+		}
+		p := Priority(s)
+		patch.Priority = &p
+	}
+	if v, ok := raw["dueDate"]; ok {
+		if isJSONNull(v) {
+			patch.ClearDueDate = true
+		} else {
+			var t time.Time
+			if err := json.Unmarshal(v, &t); err != nil {
+				return Patch{}, &ValidationError{Field: "dueDate", Message: "dueDate must be RFC3339 timestamp or null"}
+			}
+			patch.DueDate = &t
+		}
+	}
+	return patch, nil
+}
+
+// isJSONNull reports whether the raw message is the literal "null" (modulo whitespace).
+func isJSONNull(b json.RawMessage) bool {
+	return string(bytes.TrimSpace(b)) == "null"
+}
+
+// jsonDecodeError is a sentinel-style type wrapping JSON parse failures
+// so writeError emits invalid_json instead of validation_failed.
+type jsonDecodeError struct{}
+
+func (jsonDecodeError) Error() string { return "invalid_json" }
+
 // writeError maps domain errors to JSON error responses with appropriate HTTP status codes.
-// *ValidationError → 400 validation_failed (with field detail), ErrNotFound → 404 not_found,
-// all else → 500 internal_error (logged).
+// *jsonDecodeError → 400 invalid_json, *ValidationError → 400 validation_failed (with field detail),
+// ErrNotFound → 404 not_found, all else → 500 internal_error (logged).
 func writeError(c echo.Context, err error) error {
 	var verr *ValidationError
+	var jerr *jsonDecodeError
 	switch {
+	case errors.As(err, &jerr):
+		return c.JSON(http.StatusBadRequest, errBody("invalid_json", "request body is not valid JSON", nil))
 	case errors.As(err, &verr):
 		var details map[string]any
 		if verr.Field != "" {

--- a/ai/superpowers/todo/backend/todo/handler.go
+++ b/ai/superpowers/todo/backend/todo/handler.go
@@ -68,6 +68,44 @@ func errBody(code, msg string, details map[string]any) echo.Map {
 	return echo.Map{"error": body}
 }
 
+// List handles GET /api/todos with optional status/sort/order query params.
+// Empty params apply defaults (status=all, sort=createdAt, order=desc).
+func (h *Handler) List(c echo.Context) error {
+	q, err := parseQuery(c)
+	if err != nil {
+		return writeError(c, err)
+	}
+	return c.JSON(http.StatusOK, h.store.List(q))
+}
+
+// parseQuery validates and converts URL query params into a Query.
+// Returns *ValidationError when any param has an invalid value.
+func parseQuery(c echo.Context) (Query, error) {
+	q := Query{}
+	if v := c.QueryParam("status"); v != "" {
+		s := StatusFilter(v)
+		if !s.IsValid() {
+			return Query{}, &ValidationError{Field: "status", Message: "status must be one of: all, active, completed"}
+		}
+		q.Status = s
+	}
+	if v := c.QueryParam("sort"); v != "" {
+		s := SortKey(v)
+		if !s.IsValid() {
+			return Query{}, &ValidationError{Field: "sort", Message: "sort must be one of: createdAt, dueDate, priority"}
+		}
+		q.Sort = s
+	}
+	if v := c.QueryParam("order"); v != "" {
+		o := OrderDir(v)
+		if !o.IsValid() {
+			return Query{}, &ValidationError{Field: "order", Message: "order must be one of: asc, desc"}
+		}
+		q.Order = o
+	}
+	return q, nil
+}
+
 // writeError maps domain errors to JSON error responses with appropriate HTTP status codes.
 // *ValidationError → 400 validation_failed (with field detail), ErrNotFound → 404 not_found,
 // all else → 500 internal_error (logged).

--- a/ai/superpowers/todo/backend/todo/handler.go
+++ b/ai/superpowers/todo/backend/todo/handler.go
@@ -1,0 +1,89 @@
+package todo
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+// Handler exposes the todo store as JSON HTTP endpoints.
+// It is responsible for HTTP I/O concerns only — request parsing,
+// validation shape, response serialization, status code mapping.
+// Domain logic lives in Store.
+type Handler struct {
+	store *Store
+}
+
+// NewHandler returns a Handler bound to the given store.
+func NewHandler(s *Store) *Handler {
+	return &Handler{store: s}
+}
+
+// createBody is the JSON body shape accepted by POST /api/todos.
+type createBody struct {
+	Title    string     `json:"title"`
+	Priority string     `json:"priority"`
+	DueDate  *time.Time `json:"dueDate"`
+}
+
+// Create handles POST /api/todos.
+// Body: { "title": "...", "priority"?: "...", "dueDate"?: "RFC3339" }.
+// Returns 201 with the created Todo, or 400 on validation/JSON errors.
+func (h *Handler) Create(c echo.Context) error {
+	var body createBody
+	if err := json.NewDecoder(c.Request().Body).Decode(&body); err != nil {
+		return c.JSON(http.StatusBadRequest, errBody("invalid_json", "request body is not valid JSON", nil))
+	}
+	input := NewTodo{
+		Title:    body.Title,
+		Priority: Priority(body.Priority),
+		DueDate:  body.DueDate,
+	}
+	if err := input.Validate(); err != nil {
+		return writeError(c, err)
+	}
+	created := h.store.Add(input)
+	return c.JSON(http.StatusCreated, created)
+}
+
+// Delete handles DELETE /api/todos/{id}.
+// Returns 204 on success or 404 when the id is unknown.
+func (h *Handler) Delete(c echo.Context) error {
+	id := c.Param("id")
+	if err := h.store.Delete(id); err != nil {
+		return writeError(c, err)
+	}
+	return c.NoContent(http.StatusNoContent)
+}
+
+// errBody builds the standard error envelope { "error": { code, message, details? } }.
+func errBody(code, msg string, details map[string]any) echo.Map {
+	body := echo.Map{"code": code, "message": msg}
+	if details != nil {
+		body["details"] = details
+	}
+	return echo.Map{"error": body}
+}
+
+// writeError maps domain errors to JSON error responses with appropriate HTTP status codes.
+// *ValidationError → 400 validation_failed (with field detail), ErrNotFound → 404 not_found,
+// all else → 500 internal_error (logged).
+func writeError(c echo.Context, err error) error {
+	var verr *ValidationError
+	switch {
+	case errors.As(err, &verr):
+		var details map[string]any
+		if verr.Field != "" {
+			details = map[string]any{"field": verr.Field}
+		}
+		return c.JSON(http.StatusBadRequest, errBody("validation_failed", verr.Message, details))
+	case errors.Is(err, ErrNotFound):
+		return c.JSON(http.StatusNotFound, errBody("not_found", err.Error(), nil))
+	default:
+		c.Logger().Error(err)
+		return c.JSON(http.StatusInternalServerError, errBody("internal_error", "internal server error", nil))
+	}
+}

--- a/ai/superpowers/todo/backend/todo/handler_test.go
+++ b/ai/superpowers/todo/backend/todo/handler_test.go
@@ -115,3 +115,60 @@ func TestHandler_Create_201BodyShape(t *testing.T) {
 	assert.False(t, got.CreatedAt.IsZero())
 	assert.Equal(t, got.CreatedAt, got.UpdatedAt)
 }
+
+func TestHandler_List_Defaults(t *testing.T) {
+	t.Parallel()
+	h, s := newTestHandler(t)
+	s.Add(NewTodo{Title: "first"})
+	s.Add(NewTodo{Title: "second"})
+
+	_, c, rec := newJSONRequest(http.MethodGet, "/api/todos", "")
+	assert.NoError(t, h.List(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+	assert.Contains(t, body, `"title":"first"`)
+	assert.Contains(t, body, `"title":"second"`)
+	assert.True(t, strings.HasPrefix(strings.TrimSpace(body), "["))
+}
+
+func TestHandler_List_FilterAndSort(t *testing.T) {
+	t.Parallel()
+	h, s := newTestHandler(t)
+	a := s.Add(NewTodo{Title: "active"})
+	b := s.Add(NewTodo{Title: "done"})
+	completed := true
+	if _, err := s.Update(b.ID, Patch{Completed: &completed}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	_ = a
+
+	_, c, rec := newJSONRequest(http.MethodGet, "/api/todos?status=active", "")
+	assert.NoError(t, h.List(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+	assert.Contains(t, body, `"title":"active"`)
+	assert.NotContains(t, body, `"title":"done"`)
+}
+
+func TestHandler_List_InvalidQueryParam(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{"bad status", "status=invalid"},
+		{"bad sort", "sort=garbage"},
+		{"bad order", "order=sideways"},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			h, _ := newTestHandler(t)
+			_, c, rec := newJSONRequest(http.MethodGet, "/api/todos?"+tc.query, "")
+			assert.NoError(t, h.List(c))
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+			assert.Contains(t, rec.Body.String(), `"code":"validation_failed"`)
+		})
+	}
+}

--- a/ai/superpowers/todo/backend/todo/handler_test.go
+++ b/ai/superpowers/todo/backend/todo/handler_test.go
@@ -172,3 +172,143 @@ func TestHandler_List_InvalidQueryParam(t *testing.T) {
 		})
 	}
 }
+
+func TestHandler_Update_PatchSemantics(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		body       string
+		wantStatus int
+		wantInBody string
+		wantField  string
+	}{
+		{
+			name:       "completed only",
+			body:       `{"completed":true}`,
+			wantStatus: http.StatusOK,
+			wantInBody: `"completed":true`,
+		},
+		{
+			name:       "clear duedate",
+			body:       `{"dueDate":null}`,
+			wantStatus: http.StatusOK,
+			wantInBody: `"dueDate":null`,
+		},
+		{
+			name:       "set duedate",
+			body:       `{"dueDate":"2026-05-15T18:00:00Z"}`,
+			wantStatus: http.StatusOK,
+			wantInBody: `"dueDate":"2026-05-15T18:00:00Z"`,
+		},
+		{
+			name:       "title only",
+			body:       `{"title":"updated"}`,
+			wantStatus: http.StatusOK,
+			wantInBody: `"title":"updated"`,
+		},
+		{
+			name:       "priority only",
+			body:       `{"priority":"high"}`,
+			wantStatus: http.StatusOK,
+			wantInBody: `"priority":"high"`,
+		},
+		{
+			name:       "empty body",
+			body:       `{}`,
+			wantStatus: http.StatusBadRequest,
+			wantInBody: `"validation_failed"`,
+		},
+		{
+			name:       "title null rejected",
+			body:       `{"title":null}`,
+			wantStatus: http.StatusBadRequest,
+			wantInBody: `"validation_failed"`,
+			wantField:  "title",
+		},
+		{
+			name:       "completed null rejected",
+			body:       `{"completed":null}`,
+			wantStatus: http.StatusBadRequest,
+			wantInBody: `"validation_failed"`,
+			wantField:  "completed",
+		},
+		{
+			name:       "priority null rejected",
+			body:       `{"priority":null}`,
+			wantStatus: http.StatusBadRequest,
+			wantInBody: `"validation_failed"`,
+			wantField:  "priority",
+		},
+		{
+			name:       "invalid priority",
+			body:       `{"priority":"urgent"}`,
+			wantStatus: http.StatusBadRequest,
+			wantInBody: `"validation_failed"`,
+			wantField:  "priority",
+		},
+		{
+			name:       "bad duedate string",
+			body:       `{"dueDate":"not-a-date"}`,
+			wantStatus: http.StatusBadRequest,
+			wantInBody: `"validation_failed"`,
+			wantField:  "dueDate",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			h, s := newTestHandler(t)
+			added := s.Add(NewTodo{Title: "x"})
+
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPatch, "/api/todos/"+added.ID, strings.NewReader(tc.body))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetParamNames("id")
+			c.SetParamValues(added.ID)
+
+			assert.NoError(t, h.Update(c))
+			assert.Equal(t, tc.wantStatus, rec.Code, "body: %s", rec.Body.String())
+			assert.Contains(t, rec.Body.String(), tc.wantInBody)
+			if tc.wantField != "" {
+				assert.Contains(t, rec.Body.String(), `"field":"`+tc.wantField+`"`)
+			}
+		})
+	}
+}
+
+func TestHandler_Update_NotFound(t *testing.T) {
+	t.Parallel()
+	h, _ := newTestHandler(t)
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPatch, "/api/todos/nope", strings.NewReader(`{"completed":true}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("nope")
+
+	assert.NoError(t, h.Update(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"code":"not_found"`)
+}
+
+func TestHandler_Update_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	h, s := newTestHandler(t)
+	added := s.Add(NewTodo{Title: "x"})
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPatch, "/api/todos/"+added.ID, strings.NewReader(`{not json`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(added.ID)
+
+	assert.NoError(t, h.Update(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"code":"invalid_json"`)
+}

--- a/ai/superpowers/todo/backend/todo/handler_test.go
+++ b/ai/superpowers/todo/backend/todo/handler_test.go
@@ -1,0 +1,89 @@
+package todo
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestHandler(t *testing.T) (*Handler, *Store) {
+	t.Helper()
+	s := NewStore()
+	return NewHandler(s), s
+}
+
+func newJSONRequest(method, path, body string) (*echo.Echo, echo.Context, *httptest.ResponseRecorder) {
+	e := echo.New()
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	return e, c, rec
+}
+
+func TestHandler_Create_Returns201WithBody(t *testing.T) {
+	t.Parallel()
+	h, _ := newTestHandler(t)
+	_, c, rec := newJSONRequest(http.MethodPost, "/api/todos", `{"title":"buy milk"}`)
+	assert.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusCreated, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"title":"buy milk"`)
+	assert.Contains(t, rec.Body.String(), `"priority":"medium"`)
+}
+
+func TestHandler_Create_Returns400OnEmptyTitle(t *testing.T) {
+	t.Parallel()
+	h, _ := newTestHandler(t)
+	_, c, rec := newJSONRequest(http.MethodPost, "/api/todos", `{"title":"  "}`)
+	assert.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"code":"validation_failed"`)
+	assert.Contains(t, rec.Body.String(), `"field":"title"`)
+}
+
+func TestHandler_Create_Returns400OnInvalidJSON(t *testing.T) {
+	t.Parallel()
+	h, _ := newTestHandler(t)
+	_, c, rec := newJSONRequest(http.MethodPost, "/api/todos", `{not json`)
+	assert.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"code":"invalid_json"`)
+}
+
+func TestHandler_Delete_Returns204(t *testing.T) {
+	t.Parallel()
+	h, s := newTestHandler(t)
+	added := s.Add(NewTodo{Title: "x"})
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodDelete, "/api/todos/"+added.ID, nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(added.ID)
+
+	assert.NoError(t, h.Delete(c))
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	_, ok := s.Get(added.ID)
+	assert.False(t, ok)
+}
+
+func TestHandler_Delete_Returns404OnUnknownID(t *testing.T) {
+	t.Parallel()
+	h, _ := newTestHandler(t)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodDelete, "/api/todos/nope", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("nope")
+
+	assert.NoError(t, h.Delete(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"code":"not_found"`)
+}

--- a/ai/superpowers/todo/backend/todo/handler_test.go
+++ b/ai/superpowers/todo/backend/todo/handler_test.go
@@ -1,6 +1,7 @@
 package todo
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -86,4 +87,31 @@ func TestHandler_Delete_Returns404OnUnknownID(t *testing.T) {
 	assert.NoError(t, h.Delete(c))
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 	assert.Contains(t, rec.Body.String(), `"code":"not_found"`)
+}
+
+func TestHandler_Create_Returns400OnInvalidPriority(t *testing.T) {
+	t.Parallel()
+	h, _ := newTestHandler(t)
+	_, c, rec := newJSONRequest(http.MethodPost, "/api/todos", `{"title":"x","priority":"urgent"}`)
+	assert.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"code":"validation_failed"`)
+	assert.Contains(t, rec.Body.String(), `"field":"priority"`)
+}
+
+func TestHandler_Create_201BodyShape(t *testing.T) {
+	t.Parallel()
+	h, _ := newTestHandler(t)
+	_, c, rec := newJSONRequest(http.MethodPost, "/api/todos", `{"title":"buy milk","priority":"high"}`)
+	assert.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusCreated, rec.Code)
+
+	var got Todo
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.NotEmpty(t, got.ID, "server must assign an id")
+	assert.Equal(t, "buy milk", got.Title)
+	assert.Equal(t, PriorityHigh, got.Priority)
+	assert.False(t, got.Completed)
+	assert.False(t, got.CreatedAt.IsZero())
+	assert.Equal(t, got.CreatedAt, got.UpdatedAt)
 }

--- a/ai/superpowers/todo/backend/todo/store.go
+++ b/ai/superpowers/todo/backend/todo/store.go
@@ -36,7 +36,7 @@ func (s *Store) Add(input NewTodo) Todo {
 		Title:     strings.TrimSpace(input.Title),
 		Completed: false,
 		Priority:  priority,
-		DueDate:   input.DueDate,
+		DueDate:   copyTimePointer(input.DueDate),
 		CreatedAt: now,
 		UpdatedAt: now,
 	}
@@ -79,7 +79,7 @@ func (s *Store) Update(id string, p Patch) (Todo, error) {
 	if p.ClearDueDate {
 		t.DueDate = nil
 	} else if p.DueDate != nil {
-		t.DueDate = p.DueDate
+		t.DueDate = copyTimePointer(p.DueDate)
 	}
 	t.UpdatedAt = time.Now().UTC()
 	s.todos[id] = t
@@ -268,4 +268,15 @@ func compareTime(a, b time.Time) int {
 		return 1
 	}
 	return 0
+}
+
+// copyTimePointer returns a fresh *time.Time pointing to a copy of *t,
+// or nil when t is nil. Used in Add/Update to prevent external mutation
+// of stored DueDate via pointer aliasing.
+func copyTimePointer(t *time.Time) *time.Time {
+	if t == nil {
+		return nil
+	}
+	v := *t
+	return &v
 }

--- a/ai/superpowers/todo/backend/todo/store.go
+++ b/ai/superpowers/todo/backend/todo/store.go
@@ -1,6 +1,7 @@
 package todo
 
 import (
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -94,4 +95,177 @@ func (s *Store) Delete(id string) error {
 	}
 	delete(s.todos, id)
 	return nil
+}
+
+// StatusFilter narrows List results by completion state.
+type StatusFilter string
+
+const (
+	StatusAll       StatusFilter = "all"
+	StatusActive    StatusFilter = "active"
+	StatusCompleted StatusFilter = "completed"
+)
+
+// IsValid reports whether s is one of the defined StatusFilter constants.
+func (s StatusFilter) IsValid() bool {
+	switch s {
+	case StatusAll, StatusActive, StatusCompleted:
+		return true
+	default:
+		return false
+	}
+}
+
+// SortKey selects the field used to order List results.
+type SortKey string
+
+const (
+	SortCreatedAt SortKey = "createdAt"
+	SortDueDate   SortKey = "dueDate"
+	SortPriority  SortKey = "priority"
+)
+
+// IsValid reports whether k is one of the defined SortKey constants.
+func (k SortKey) IsValid() bool {
+	switch k {
+	case SortCreatedAt, SortDueDate, SortPriority:
+		return true
+	default:
+		return false
+	}
+}
+
+// OrderDir is ascending or descending.
+type OrderDir string
+
+const (
+	OrderAsc  OrderDir = "asc"
+	OrderDesc OrderDir = "desc"
+)
+
+// IsValid reports whether o is one of the defined OrderDir constants.
+func (o OrderDir) IsValid() bool {
+	switch o {
+	case OrderAsc, OrderDesc:
+		return true
+	default:
+		return false
+	}
+}
+
+// Query is the input to Store.List. Zero values mean defaults:
+// Status defaults to StatusAll, Sort to SortCreatedAt, Order to OrderDesc.
+type Query struct {
+	Status StatusFilter
+	Sort   SortKey
+	Order  OrderDir
+}
+
+func (q Query) withDefaults() Query {
+	if q.Status == "" {
+		q.Status = StatusAll
+	}
+	if q.Sort == "" {
+		q.Sort = SortCreatedAt
+	}
+	if q.Order == "" {
+		q.Order = OrderDesc
+	}
+	return q
+}
+
+// List returns todos matching the query, sorted as requested.
+// nil dueDate values are placed last regardless of Order (deterministic).
+// Tie-breaks fall back to createdAt ascending (stable sort).
+func (s *Store) List(q Query) []Todo {
+	q = q.withDefaults()
+	s.mu.RLock()
+	out := make([]Todo, 0, len(s.todos))
+	for _, t := range s.todos {
+		if !matchesStatus(t, q.Status) {
+			continue
+		}
+		out = append(out, t)
+	}
+	s.mu.RUnlock()
+	sortTodos(out, q.Sort, q.Order)
+	return out
+}
+
+func matchesStatus(t Todo, f StatusFilter) bool {
+	switch f {
+	case StatusActive:
+		return !t.Completed
+	case StatusCompleted:
+		return t.Completed
+	default:
+		return true
+	}
+}
+
+// sortTodos sorts ts in place by the given key/order.
+// nil dueDate values always sort last regardless of order (deterministic).
+// Tie-breaks fall back to createdAt ascending (stable sort).
+func sortTodos(ts []Todo, key SortKey, order OrderDir) {
+	asc := order == OrderAsc
+	sort.SliceStable(ts, func(i, j int) bool {
+		a, b := ts[i], ts[j]
+
+		// dueDate 정렬: nil은 항상 마지막 (asc/desc 무관)
+		if key == SortDueDate {
+			if a.DueDate == nil && b.DueDate == nil {
+				return a.CreatedAt.Before(b.CreatedAt)
+			}
+			if a.DueDate == nil {
+				return false
+			}
+			if b.DueDate == nil {
+				return true
+			}
+		}
+
+		cmp := primaryCompare(a, b, key)
+		if cmp == 0 {
+			return a.CreatedAt.Before(b.CreatedAt) // tie-break: createdAt asc
+		}
+		if asc {
+			return cmp < 0
+		}
+		return cmp > 0
+	})
+}
+
+func primaryCompare(a, b Todo, key SortKey) int {
+	switch key {
+	case SortPriority:
+		return priorityRank(a.Priority) - priorityRank(b.Priority)
+	case SortDueDate:
+		// 호출 시점에 둘 다 non-nil 보장됨 (sortTodos에서 nil 분기)
+		return compareTime(*a.DueDate, *b.DueDate)
+	default: // SortCreatedAt
+		return compareTime(a.CreatedAt, b.CreatedAt)
+	}
+}
+
+func priorityRank(p Priority) int {
+	switch p {
+	case PriorityLow:
+		return 1
+	case PriorityMedium:
+		return 2
+	case PriorityHigh:
+		return 3
+	default:
+		return 0
+	}
+}
+
+func compareTime(a, b time.Time) int {
+	if a.Before(b) {
+		return -1
+	}
+	if a.After(b) {
+		return 1
+	}
+	return 0
 }

--- a/ai/superpowers/todo/backend/todo/store.go
+++ b/ai/superpowers/todo/backend/todo/store.go
@@ -1,0 +1,97 @@
+package todo
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Store is an in-memory, concurrency-safe collection of Todo values.
+// All read methods take an RLock; mutations take a Lock.
+// Returned values are copies — callers cannot affect stored state by mutation.
+type Store struct {
+	mu    sync.RWMutex
+	todos map[string]Todo
+}
+
+// NewStore creates an empty Store ready for use.
+func NewStore() *Store {
+	return &Store{todos: make(map[string]Todo)}
+}
+
+// Add assigns ID/timestamps/default priority, stores the todo, and returns a copy.
+// Title is trimmed before storing. Add does NOT call NewTodo.Validate — callers
+// must validate at the boundary (handler) before invoking Add.
+func (s *Store) Add(input NewTodo) Todo {
+	now := time.Now().UTC()
+	priority := input.Priority
+	if priority == "" {
+		priority = PriorityMedium
+	}
+	t := Todo{
+		ID:        uuid.NewString(),
+		Title:     strings.TrimSpace(input.Title),
+		Completed: false,
+		Priority:  priority,
+		DueDate:   input.DueDate,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	s.mu.Lock()
+	s.todos[t.ID] = t
+	s.mu.Unlock()
+	return t
+}
+
+// Get returns the todo with the given id and true, or zero value and false.
+func (s *Store) Get(id string) (Todo, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	t, ok := s.todos[id]
+	return t, ok
+}
+
+// Update applies the patch to the todo identified by id.
+// Returns ErrNotFound when id is unknown, or *ValidationError when patch is invalid.
+// Validates the patch before applying.
+func (s *Store) Update(id string, p Patch) (Todo, error) {
+	if err := p.Validate(); err != nil {
+		return Todo{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	t, ok := s.todos[id]
+	if !ok {
+		return Todo{}, ErrNotFound
+	}
+	if p.Title != nil {
+		t.Title = strings.TrimSpace(*p.Title)
+	}
+	if p.Completed != nil {
+		t.Completed = *p.Completed
+	}
+	if p.Priority != nil {
+		t.Priority = *p.Priority
+	}
+	if p.ClearDueDate {
+		t.DueDate = nil
+	} else if p.DueDate != nil {
+		t.DueDate = p.DueDate
+	}
+	t.UpdatedAt = time.Now().UTC()
+	s.todos[id] = t
+	return t, nil
+}
+
+// Delete removes the todo by id. Returns ErrNotFound when id is unknown.
+func (s *Store) Delete(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.todos[id]; !ok {
+		return ErrNotFound
+	}
+	delete(s.todos, id)
+	return nil
+}

--- a/ai/superpowers/todo/backend/todo/store_test.go
+++ b/ai/superpowers/todo/backend/todo/store_test.go
@@ -1,0 +1,124 @@
+package todo
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	return NewStore()
+}
+
+func TestStore_Add_AssignsIDAndTimestamps(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	before := time.Now()
+	got := s.Add(NewTodo{Title: "buy milk"})
+	after := time.Now()
+
+	assert.NotEmpty(t, got.ID)
+	assert.Equal(t, "buy milk", got.Title)
+	assert.False(t, got.Completed)
+	assert.Equal(t, PriorityMedium, got.Priority, "default priority")
+	assert.Nil(t, got.DueDate)
+	assert.False(t, got.CreatedAt.Before(before))
+	assert.False(t, got.CreatedAt.After(after))
+	assert.Equal(t, got.CreatedAt, got.UpdatedAt)
+}
+
+func TestStore_Add_TrimsTitle(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	got := s.Add(NewTodo{Title: "  buy milk  "})
+	assert.Equal(t, "buy milk", got.Title)
+}
+
+func TestStore_Add_RespectsPriorityWhenProvided(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	got := s.Add(NewTodo{Title: "x", Priority: PriorityHigh})
+	assert.Equal(t, PriorityHigh, got.Priority)
+}
+
+func TestStore_Get_ReturnsCopy(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	added := s.Add(NewTodo{Title: "x"})
+	got, ok := s.Get(added.ID)
+	assert.True(t, ok)
+	assert.Equal(t, added, got)
+
+	got.Title = "mutated"
+	again, _ := s.Get(added.ID)
+	assert.Equal(t, "x", again.Title, "store copy must not be affected by external mutation")
+}
+
+func TestStore_Get_NotFound(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	_, ok := s.Get("nope")
+	assert.False(t, ok)
+}
+
+func TestStore_Update_PartialFields(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	added := s.Add(NewTodo{Title: "x"})
+	time.Sleep(time.Millisecond) // updatedAt 비교를 위한 1ms 차이
+
+	completed := true
+	newTitle := "y"
+	got, err := s.Update(added.ID, Patch{Title: &newTitle, Completed: &completed})
+	assert.NoError(t, err)
+	assert.Equal(t, "y", got.Title)
+	assert.True(t, got.Completed)
+	assert.True(t, got.UpdatedAt.After(added.UpdatedAt))
+	assert.Equal(t, added.CreatedAt, got.CreatedAt, "createdAt must not change")
+}
+
+func TestStore_Update_ClearDueDate(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	due := time.Now().Add(time.Hour)
+	added := s.Add(NewTodo{Title: "x", DueDate: &due})
+	got, err := s.Update(added.ID, Patch{ClearDueDate: true})
+	assert.NoError(t, err)
+	assert.Nil(t, got.DueDate)
+}
+
+func TestStore_Update_NotFound(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	completed := true
+	_, err := s.Update("nope", Patch{Completed: &completed})
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestStore_Update_ValidationError(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	added := s.Add(NewTodo{Title: "x"})
+	empty := ""
+	_, err := s.Update(added.ID, Patch{Title: &empty})
+	var verr *ValidationError
+	assert.ErrorAs(t, err, &verr)
+	assert.Equal(t, "title", verr.Field)
+}
+
+func TestStore_Delete_Success(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	added := s.Add(NewTodo{Title: "x"})
+	assert.NoError(t, s.Delete(added.ID))
+	_, ok := s.Get(added.ID)
+	assert.False(t, ok)
+}
+
+func TestStore_Delete_NotFound(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	assert.ErrorIs(t, s.Delete("nope"), ErrNotFound)
+}

--- a/ai/superpowers/todo/backend/todo/store_test.go
+++ b/ai/superpowers/todo/backend/todo/store_test.go
@@ -1,6 +1,7 @@
 package todo
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -121,4 +122,124 @@ func TestStore_Delete_NotFound(t *testing.T) {
 	t.Parallel()
 	s := newTestStore(t)
 	assert.ErrorIs(t, s.Delete("nope"), ErrNotFound)
+}
+
+func TestStore_List_FilterByStatus(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	a := s.Add(NewTodo{Title: "active"})
+	b := s.Add(NewTodo{Title: "done"})
+	completed := true
+	if _, err := s.Update(b.ID, Patch{Completed: &completed}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	_ = a
+
+	tests := []struct {
+		status    StatusFilter
+		wantLen   int
+		wantTitle string
+	}{
+		{StatusAll, 2, ""},
+		{StatusActive, 1, "active"},
+		{StatusCompleted, 1, "done"},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(string(tc.status), func(t *testing.T) {
+			t.Parallel()
+			got := s.List(Query{Status: tc.status})
+			assert.Len(t, got, tc.wantLen)
+			if tc.wantTitle != "" && len(got) == 1 {
+				assert.Equal(t, tc.wantTitle, got[0].Title)
+			}
+		})
+	}
+}
+
+func TestStore_List_SortByPriority(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	low := s.Add(NewTodo{Title: "low", Priority: PriorityLow})
+	high := s.Add(NewTodo{Title: "high", Priority: PriorityHigh})
+	mid := s.Add(NewTodo{Title: "mid", Priority: PriorityMedium})
+
+	asc := s.List(Query{Sort: SortPriority, Order: OrderAsc})
+	assert.Equal(t, []string{low.ID, mid.ID, high.ID}, ids(asc))
+
+	desc := s.List(Query{Sort: SortPriority, Order: OrderDesc})
+	assert.Equal(t, []string{high.ID, mid.ID, low.ID}, ids(desc))
+}
+
+func TestStore_List_SortByDueDate_NilLast(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	t1 := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	a := s.Add(NewTodo{Title: "a", DueDate: &t2})
+	b := s.Add(NewTodo{Title: "b", DueDate: nil})
+	c := s.Add(NewTodo{Title: "c", DueDate: &t1})
+
+	asc := s.List(Query{Sort: SortDueDate, Order: OrderAsc})
+	assert.Equal(t, []string{c.ID, a.ID, b.ID}, ids(asc), "nil dueDate must be last")
+
+	desc := s.List(Query{Sort: SortDueDate, Order: OrderDesc})
+	assert.Equal(t, []string{a.ID, c.ID, b.ID}, ids(desc), "nil dueDate must be last regardless of order")
+}
+
+func TestStore_List_SortByCreatedAt_DescDefault(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	first := s.Add(NewTodo{Title: "first"})
+	time.Sleep(time.Millisecond)
+	second := s.Add(NewTodo{Title: "second"})
+
+	desc := s.List(Query{}) // default sort=createdAt, order=desc
+	assert.Equal(t, []string{second.ID, first.ID}, ids(desc))
+}
+
+func TestStore_List_TieBreakByCreatedAtAsc(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	a := s.Add(NewTodo{Title: "a", Priority: PriorityHigh})
+	time.Sleep(time.Millisecond)
+	b := s.Add(NewTodo{Title: "b", Priority: PriorityHigh})
+
+	asc := s.List(Query{Sort: SortPriority, Order: OrderAsc})
+	assert.Equal(t, []string{a.ID, b.ID}, ids(asc))
+}
+
+func TestStore_ConcurrentAddList(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			s.Add(NewTodo{Title: "t"})
+		}(i)
+	}
+	done := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				_ = s.List(Query{})
+			}
+		}
+	}()
+	wg.Wait()
+	close(done)
+	assert.Len(t, s.List(Query{}), 100)
+}
+
+func ids(ts []Todo) []string {
+	out := make([]string, len(ts))
+	for i, t := range ts {
+		out[i] = t.ID
+	}
+	return out
 }

--- a/ai/superpowers/todo/backend/todo/store_test.go
+++ b/ai/superpowers/todo/backend/todo/store_test.go
@@ -243,3 +243,36 @@ func ids(ts []Todo) []string {
 	}
 	return out
 }
+
+func TestStore_Add_DueDateNotAliased(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	due := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	added := s.Add(NewTodo{Title: "x", DueDate: &due})
+
+	// Mutate caller's pointer target.
+	due = due.Add(24 * time.Hour)
+
+	got, ok := s.Get(added.ID)
+	assert.True(t, ok)
+	assert.NotNil(t, got.DueDate)
+	assert.Equal(t, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC), *got.DueDate,
+		"caller mutation must not leak into stored state")
+}
+
+func TestStore_Update_DueDateNotAliased(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	added := s.Add(NewTodo{Title: "x"})
+	due := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	_, err := s.Update(added.ID, Patch{DueDate: &due})
+	assert.NoError(t, err)
+
+	due = due.Add(24 * time.Hour)
+
+	got, ok := s.Get(added.ID)
+	assert.True(t, ok)
+	assert.NotNil(t, got.DueDate)
+	assert.Equal(t, time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC), *got.DueDate)
+}

--- a/ai/superpowers/todo/backend/todo/todo.go
+++ b/ai/superpowers/todo/backend/todo/todo.go
@@ -1,0 +1,112 @@
+// Package todo defines the domain model and in-memory store for the
+// superpowers todo learning sample. The store is concurrency-safe via
+// sync.RWMutex, and the package exposes only value types so that
+// callers cannot mutate stored state through returned references.
+package todo
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Priority is the importance level of a todo item.
+type Priority string
+
+const (
+	PriorityLow    Priority = "low"
+	PriorityMedium Priority = "medium"
+	PriorityHigh   Priority = "high"
+)
+
+// IsValid reports whether p is one of the defined Priority constants.
+func (p Priority) IsValid() bool {
+	switch p {
+	case PriorityLow, PriorityMedium, PriorityHigh:
+		return true
+	default:
+		return false
+	}
+}
+
+// Todo is the domain entity. ID, CreatedAt, UpdatedAt are server-managed.
+type Todo struct {
+	ID        string     `json:"id"`
+	Title     string     `json:"title"`
+	Completed bool       `json:"completed"`
+	Priority  Priority   `json:"priority"`
+	DueDate   *time.Time `json:"dueDate"`
+	CreatedAt time.Time  `json:"createdAt"`
+	UpdatedAt time.Time  `json:"updatedAt"`
+}
+
+// NewTodo is the input type for Store.Add. Title is required.
+// Priority defaults to PriorityMedium when empty. DueDate is optional.
+type NewTodo struct {
+	Title    string
+	Priority Priority
+	DueDate  *time.Time
+}
+
+// Validate returns a *ValidationError when input is rejected, otherwise nil.
+// Title is trimmed before length check (1-200 chars).
+// Priority must be empty (defaulted later) or one of the defined constants.
+func (n NewTodo) Validate() error {
+	title := strings.TrimSpace(n.Title)
+	if title == "" {
+		return &ValidationError{Field: "title", Message: "title is required"}
+	}
+	if len(title) > 200 {
+		return &ValidationError{Field: "title", Message: "title must be at most 200 characters"}
+	}
+	if n.Priority != "" && !n.Priority.IsValid() {
+		return &ValidationError{Field: "priority", Message: fmt.Sprintf("priority %q is invalid", n.Priority)}
+	}
+	return nil
+}
+
+// Patch describes a partial update to a Todo.
+// A nil pointer means "field absent in request" (no change).
+// ClearDueDate true means the request explicitly set dueDate to null.
+type Patch struct {
+	Title        *string
+	Completed    *bool
+	Priority     *Priority
+	DueDate      *time.Time
+	ClearDueDate bool
+}
+
+// Validate returns *ValidationError when patch is invalid.
+// An empty patch (no fields set) is considered an error to match the API contract.
+func (p Patch) Validate() error {
+	if p.Title == nil && p.Completed == nil && p.Priority == nil && p.DueDate == nil && !p.ClearDueDate {
+		return &ValidationError{Field: "", Message: "request body must contain at least one field"}
+	}
+	if p.Title != nil {
+		t := strings.TrimSpace(*p.Title)
+		if t == "" {
+			return &ValidationError{Field: "title", Message: "title is required"}
+		}
+		if len(t) > 200 {
+			return &ValidationError{Field: "title", Message: "title must be at most 200 characters"}
+		}
+	}
+	if p.Priority != nil && !p.Priority.IsValid() {
+		return &ValidationError{Field: "priority", Message: fmt.Sprintf("priority %q is invalid", *p.Priority)}
+	}
+	return nil
+}
+
+// ValidationError indicates a field-level validation failure.
+// Field may be empty for whole-body errors.
+type ValidationError struct {
+	Field   string
+	Message string
+}
+
+// Error implements error.
+func (e *ValidationError) Error() string { return e.Message }
+
+// ErrNotFound is returned by Store.Update and Store.Delete when the id is unknown.
+var ErrNotFound = errors.New("todo not found")

--- a/ai/superpowers/todo/backend/todo/todo.go
+++ b/ai/superpowers/todo/backend/todo/todo.go
@@ -1,7 +1,7 @@
-// Package todo defines the domain model and in-memory store for the
-// superpowers todo learning sample. The store is concurrency-safe via
-// sync.RWMutex, and the package exposes only value types so that
-// callers cannot mutate stored state through returned references.
+// Package todo defines the domain model and (in later phases) an
+// in-memory, concurrency-safe store for the superpowers todo learning sample.
+// All stored values are passed by value so callers cannot mutate stored
+// state through returned references.
 package todo
 
 import (
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // Priority is the importance level of a todo item.
@@ -57,7 +58,7 @@ func (n NewTodo) Validate() error {
 	if title == "" {
 		return &ValidationError{Field: "title", Message: "title is required"}
 	}
-	if len(title) > 200 {
+	if utf8.RuneCountInString(title) > 200 {
 		return &ValidationError{Field: "title", Message: "title must be at most 200 characters"}
 	}
 	if n.Priority != "" && !n.Priority.IsValid() {
@@ -88,7 +89,7 @@ func (p Patch) Validate() error {
 		if t == "" {
 			return &ValidationError{Field: "title", Message: "title is required"}
 		}
-		if len(t) > 200 {
+		if utf8.RuneCountInString(t) > 200 {
 			return &ValidationError{Field: "title", Message: "title must be at most 200 characters"}
 		}
 	}

--- a/ai/superpowers/todo/backend/todo/todo_test.go
+++ b/ai/superpowers/todo/backend/todo/todo_test.go
@@ -1,6 +1,7 @@
 package todo
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -32,10 +33,7 @@ func TestPriority_IsValid(t *testing.T) {
 func TestNewTodo_Validate(t *testing.T) {
 	t.Parallel()
 	future := time.Now().Add(24 * time.Hour)
-	tooLong := ""
-	for i := 0; i < 201; i++ {
-		tooLong += "a"
-	}
+	tooLong := strings.Repeat("a", 201)
 
 	tests := []struct {
 		name      string
@@ -48,6 +46,8 @@ func TestNewTodo_Validate(t *testing.T) {
 		{"empty title", NewTodo{Title: ""}, "title"},
 		{"whitespace title", NewTodo{Title: "   "}, "title"},
 		{"title length 201", NewTodo{Title: tooLong}, "title"},
+		{"korean title at boundary", NewTodo{Title: strings.Repeat("가", 200)}, ""},
+		{"korean title over boundary", NewTodo{Title: strings.Repeat("가", 201)}, "title"},
 		{"invalid priority", NewTodo{Title: "x", Priority: Priority("urgent")}, "priority"},
 	}
 	for _, tc := range tests {
@@ -83,10 +83,7 @@ func TestNewTodo_Validate_TitleLengthBoundaries(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			title := ""
-			for i := 0; i < tc.titleLen; i++ {
-				title += "a"
-			}
+			title := strings.Repeat("a", tc.titleLen)
 			err := NewTodo{Title: title}.Validate()
 			if tc.wantValid {
 				assert.NoError(t, err)

--- a/ai/superpowers/todo/backend/todo/todo_test.go
+++ b/ai/superpowers/todo/backend/todo/todo_test.go
@@ -1,0 +1,98 @@
+package todo
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPriority_IsValid(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		p    Priority
+		want bool
+	}{
+		{"low", PriorityLow, true},
+		{"medium", PriorityMedium, true},
+		{"high", PriorityHigh, true},
+		{"empty", Priority(""), false},
+		{"unknown", Priority("urgent"), false},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, tc.p.IsValid())
+		})
+	}
+}
+
+func TestNewTodo_Validate(t *testing.T) {
+	t.Parallel()
+	future := time.Now().Add(24 * time.Hour)
+	tooLong := ""
+	for i := 0; i < 201; i++ {
+		tooLong += "a"
+	}
+
+	tests := []struct {
+		name      string
+		input     NewTodo
+		wantField string // 빈 문자열이면 통과 기대
+	}{
+		{"title only", NewTodo{Title: "buy milk"}, ""},
+		{"title with priority", NewTodo{Title: "x", Priority: PriorityHigh}, ""},
+		{"title with future due", NewTodo{Title: "x", DueDate: &future}, ""},
+		{"empty title", NewTodo{Title: ""}, "title"},
+		{"whitespace title", NewTodo{Title: "   "}, "title"},
+		{"title length 201", NewTodo{Title: tooLong}, "title"},
+		{"invalid priority", NewTodo{Title: "x", Priority: Priority("urgent")}, "priority"},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.input.Validate()
+			if tc.wantField == "" {
+				assert.NoError(t, err)
+				return
+			}
+			var verr *ValidationError
+			if assert.ErrorAs(t, err, &verr) {
+				assert.Equal(t, tc.wantField, verr.Field)
+			}
+		})
+	}
+}
+
+func TestNewTodo_Validate_TitleLengthBoundaries(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		titleLen  int
+		wantValid bool
+	}{
+		{"len 1", 1, true},
+		{"len 200", 200, true},
+		{"len 0", 0, false},
+		{"len 201", 201, false},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			title := ""
+			for i := 0; i < tc.titleLen; i++ {
+				title += "a"
+			}
+			err := NewTodo{Title: title}.Validate()
+			if tc.wantValid {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}

--- a/ai/superpowers/todo/docs/superpowers/plans/2026-04-30-todo-app-plan.md
+++ b/ai/superpowers/todo/docs/superpowers/plans/2026-04-30-todo-app-plan.md
@@ -1,0 +1,3551 @@
+# Todo Web Application Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Echo (Go 1.26) + React 19 (Vite + TypeScript) 기반 in-memory Todo 웹 애플리케이션을 TDD 사이클로 처음부터 구현하면서 superpowers skill 사이클을 풀로 체험한다.
+
+**Architecture:** 두 프로세스 분리 (BE :8080 / FE :5173, Vite proxy로 `/api/*` 포워딩). 백엔드는 `server` (라우팅) → `todo.Handler` (HTTP I/O) → `todo.Store` (도메인) 3계층. Store는 `sync.RWMutex` 보호 `map[string]Todo`. PATCH는 `map[string]json.RawMessage`로 1차 디코딩하여 키 존재/null 판별. 프론트는 단일 `useTodos` 훅이 useReducer로 상태 캡슐화, mutation 후 항상 list refetch.
+
+**Tech Stack:**
+- Backend: Go 1.26.0 (root `tutorials-go/go.mod`), Echo v4, google/uuid, testify/assert
+- Frontend: React 19, Vite, TypeScript 5, Vitest, React Testing Library, MSW
+- Spec 참조: `docs/superpowers/specs/2026-04-30-todo-app-design.md`
+
+**Scope reference**: 모든 작업은 `/Users/user/src/workspace_blog3/tutorials-go/ai/superpowers/todo/` 하위에서 수행. Go 모듈 루트는 `tutorials-go/`. 모든 git 명령은 `tutorials-go/` 디렉토리에서 실행.
+
+**커밋 규칙 (`CLAUDE.md` 준수):**
+- 형식: `[feat/todo-app] <type>: <간결한 한국어 설명>`
+- 타입: feat, fix, docs, style, refactor, test, chore
+- 본 plan에서 모든 커밋은 `feat/todo-app` 브랜치에 적재
+
+---
+
+## Pre-flight
+
+### Task A: 피처 브랜치 생성 + spec/plan 커밋
+
+**Files:**
+- Existing: `tutorials-go/ai/superpowers/todo/docs/superpowers/specs/2026-04-30-todo-app-design.md`
+- Existing: `tutorials-go/ai/superpowers/todo/docs/superpowers/plans/2026-04-30-todo-app-plan.md` (본 문서)
+
+- [ ] **Step 1: 현재 브랜치 확인**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+git status --short
+git branch --show-current
+```
+
+Expected: 현재 master, working tree에 spec/plan 두 파일이 untracked로 보임.
+
+- [ ] **Step 2: 피처 브랜치 생성 및 체크아웃**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+git checkout -b feat/todo-app
+```
+
+Expected: `Switched to a new branch 'feat/todo-app'`
+
+- [ ] **Step 3: spec + plan 커밋**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+git add ai/superpowers/todo/docs/superpowers/specs/2026-04-30-todo-app-design.md \
+        ai/superpowers/todo/docs/superpowers/plans/2026-04-30-todo-app-plan.md
+git commit -m "$(cat <<'EOF'
+[feat/todo-app] docs: superpowers todo app spec과 implementation plan 추가
+
+* 학습용 Todo 웹 애플리케이션 (Echo + React + in-memory) 설계 문서
+* superpowers skill 사이클 체험을 목적으로 함
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: 커밋 성공, 2개 파일.
+
+- [ ] **Step 4: 커밋 검증**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+git log --oneline -1
+git status --short
+```
+
+Expected: 직전 커밋 표시, working tree clean.
+
+---
+
+## Phase 0: 프로젝트 스캐폴드
+
+### Task 0.1: 디렉토리/Makefile/README 스켈레톤
+
+**Files:**
+- Create: `tutorials-go/ai/superpowers/todo/README.md`
+- Create: `tutorials-go/ai/superpowers/todo/Makefile`
+- Create: `tutorials-go/ai/superpowers/todo/.gitignore`
+
+- [ ] **Step 1: 디렉토리 골격 생성**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go/ai/superpowers/todo
+mkdir -p backend/server backend/todo frontend
+```
+
+Expected: 디렉토리 4개 생성됨.
+
+- [ ] **Step 2: README 스켈레톤 작성**
+
+`tutorials-go/ai/superpowers/todo/README.md` 내용:
+
+```markdown
+# Todo Web Application (superpowers 학습용)
+
+Echo (Go) + React (Vite, TypeScript) 기반 in-memory Todo 앱. superpowers plugin skill 사이클을 풀로 체험하기 위한 학습 샘플.
+
+## 실행
+
+```bash
+# Backend (포트 8080)
+make dev-be
+
+# Frontend (포트 5173, /api/* → 8080 proxy)
+make dev-fe
+```
+
+브라우저에서 http://localhost:5173 접속.
+
+## 빌드/테스트
+
+```bash
+make build           # frontend 프로덕션 빌드
+make preview-fe      # 빌드 결과 :4173 프리뷰
+make test            # backend + frontend 테스트
+make test-be         # backend만
+make test-fe         # frontend만
+```
+
+## 정책
+
+- **데이터 영속성 없음**: 서버 재시작 시 모든 todo 손실 (in-memory).
+- **시작 순서**: BE 먼저 띄운 후 FE. BE 부재 시 FE는 에러 배너 표시.
+- **동시 PATCH**: last-write-wins (버전 필드 미도입).
+- **타입 동기화**: `frontend/src/types.ts`는 백엔드 JSON 모델과 수기 동기화. BE 변경 시 같이 수정.
+
+## 문서
+
+- 설계: `docs/superpowers/specs/2026-04-30-todo-app-design.md`
+- 구현 plan: `docs/superpowers/plans/2026-04-30-todo-app-plan.md`
+```
+
+- [ ] **Step 3: Makefile 작성**
+
+`tutorials-go/ai/superpowers/todo/Makefile` 내용:
+
+```makefile
+.PHONY: dev-be dev-fe build preview-fe test test-be test-fe install clean
+
+BE_DIR := backend
+FE_DIR := frontend
+
+install:
+	cd $(FE_DIR) && npm install
+
+dev-be:
+	cd $(BE_DIR) && go run .
+
+dev-fe:
+	cd $(FE_DIR) && npm run dev
+
+build:
+	cd $(FE_DIR) && npm run build
+
+preview-fe: build
+	cd $(FE_DIR) && npm run preview
+
+test: test-be test-fe
+
+test-be:
+	cd $(BE_DIR) && go test -race ./... && go vet ./...
+
+test-fe:
+	cd $(FE_DIR) && npm test -- --run
+
+clean:
+	rm -rf $(FE_DIR)/dist $(FE_DIR)/node_modules
+```
+
+- [ ] **Step 4: .gitignore 작성**
+
+`tutorials-go/ai/superpowers/todo/.gitignore` 내용:
+
+```
+# frontend
+frontend/node_modules/
+frontend/dist/
+frontend/coverage/
+
+# misc
+.DS_Store
+*.log
+```
+
+- [ ] **Step 5: 커밋**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+git add ai/superpowers/todo/README.md \
+        ai/superpowers/todo/Makefile \
+        ai/superpowers/todo/.gitignore
+git commit -m "$(cat <<'EOF'
+[feat/todo-app] chore: 프로젝트 스켈레톤 (README, Makefile, .gitignore)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: 3개 파일 커밋.
+
+---
+
+### Task 0.2: 백엔드 Go 스캐폴드 + 의존성
+
+**Files:**
+- Create: `tutorials-go/ai/superpowers/todo/backend/main.go`
+- Modify: `tutorials-go/go.mod` (Echo + uuid + testify 추가)
+- Modify: `tutorials-go/go.sum`
+
+- [ ] **Step 1: main.go 스텁 작성**
+
+`tutorials-go/ai/superpowers/todo/backend/main.go` 내용:
+
+```go
+// Package main is the entrypoint for the superpowers todo learning sample.
+// It wires the Echo server with an in-memory todo store and starts listening on :8080.
+package main
+
+import (
+	"log"
+
+	"github.com/kenshin579/tutorials-go/ai/superpowers/todo/backend/server"
+	"github.com/kenshin579/tutorials-go/ai/superpowers/todo/backend/todo"
+)
+
+func main() {
+	store := todo.NewStore()
+	srv := server.New(store)
+	if err := srv.Start(":8080"); err != nil {
+		log.Fatalf("server failed: %v", err)
+	}
+}
+```
+
+이 파일은 아직 컴파일되지 않는다 (server, todo 패키지 미구현). Phase 1~4 완료 후 컴파일됨.
+
+- [ ] **Step 2: 의존성 다운로드**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+go get github.com/labstack/echo/v4
+go get github.com/google/uuid
+go get github.com/stretchr/testify
+go mod tidy
+```
+
+Expected: `go.mod`에 echo/v4, uuid, testify 항목 추가됨.
+
+- [ ] **Step 3: 의존성 확인**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+grep -E "echo|uuid|testify" go.mod
+```
+
+Expected: 세 의존성 모두 출력.
+
+- [ ] **Step 4: 커밋 (main.go는 아직 컴파일 안 되지만 의존성 추가는 커밋)**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+git add ai/superpowers/todo/backend/main.go go.mod go.sum
+git commit -m "$(cat <<'EOF'
+[feat/todo-app] chore: 백엔드 main.go 스텁 + Echo/uuid/testify 의존성 추가
+
+* main.go는 server/todo 패키지 구현 후 컴파일됨
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 0.3: 프론트엔드 Vite + React + TypeScript 스캐폴드
+
+**Files:**
+- Create: `tutorials-go/ai/superpowers/todo/frontend/package.json`
+- Create: `tutorials-go/ai/superpowers/todo/frontend/vite.config.ts`
+- Create: `tutorials-go/ai/superpowers/todo/frontend/tsconfig.json`
+- Create: `tutorials-go/ai/superpowers/todo/frontend/tsconfig.node.json`
+- Create: `tutorials-go/ai/superpowers/todo/frontend/index.html`
+- Create: `tutorials-go/ai/superpowers/todo/frontend/src/main.tsx`
+- Create: `tutorials-go/ai/superpowers/todo/frontend/src/App.tsx`
+- Create: `tutorials-go/ai/superpowers/todo/frontend/src/index.css`
+- Create: `tutorials-go/ai/superpowers/todo/frontend/src/__tests__/setup.ts`
+
+- [ ] **Step 1: package.json 작성**
+
+`tutorials-go/ai/superpowers/todo/frontend/package.json` 내용:
+
+```json
+{
+  "name": "superpowers-todo-frontend",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.5.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.3.0",
+    "jsdom": "^24.0.0",
+    "msw": "^2.4.0",
+    "typescript": "^5.5.0",
+    "vite": "^5.4.0",
+    "vitest": "^2.1.0"
+  }
+}
+```
+
+- [ ] **Step 2: tsconfig 작성**
+
+`tutorials-go/ai/superpowers/todo/frontend/tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}
+```
+
+`tutorials-go/ai/superpowers/todo/frontend/tsconfig.node.json`:
+
+```json
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "strict": true
+  },
+  "include": ["vite.config.ts"]
+}
+```
+
+- [ ] **Step 3: vite.config.ts 작성 (proxy + vitest)**
+
+`tutorials-go/ai/superpowers/todo/frontend/vite.config.ts`:
+
+```ts
+/// <reference types="vitest" />
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: false,
+      },
+    },
+  },
+  preview: { port: 4173 },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./src/__tests__/setup.ts'],
+  },
+})
+```
+
+- [ ] **Step 4: index.html 작성**
+
+`tutorials-go/ai/superpowers/todo/frontend/index.html`:
+
+```html
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Superpowers Todo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+```
+
+- [ ] **Step 5: 진입점 + 빈 App + CSS 작성**
+
+`tutorials-go/ai/superpowers/todo/frontend/src/main.tsx`:
+
+```tsx
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)
+```
+
+`tutorials-go/ai/superpowers/todo/frontend/src/App.tsx`:
+
+```tsx
+export default function App() {
+  return <h1>Superpowers Todo (work in progress)</h1>
+}
+```
+
+`tutorials-go/ai/superpowers/todo/frontend/src/index.css`:
+
+```css
+:root {
+  font-family: system-ui, -apple-system, sans-serif;
+  color-scheme: light dark;
+}
+
+body {
+  margin: 0;
+  padding: 1rem;
+  max-width: 640px;
+  margin-inline: auto;
+}
+```
+
+- [ ] **Step 6: Vitest setup (빈 셋업, MSW는 Phase 5에서 추가)**
+
+`tutorials-go/ai/superpowers/todo/frontend/src/__tests__/setup.ts`:
+
+```ts
+// Phase 5에서 MSW server 등록 추가됨.
+// 현재는 testing-library 자동 cleanup만 활성화 (vitest globals + jsdom으로 충분).
+```
+
+- [ ] **Step 7: 의존성 설치**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go/ai/superpowers/todo/frontend
+npm install
+```
+
+Expected: `node_modules/` 생성, `package-lock.json` 생성. 경고가 있어도 에러만 없으면 OK.
+
+- [ ] **Step 8: 부팅 검증**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go/ai/superpowers/todo/frontend
+npm run build
+```
+
+Expected: `dist/` 생성, 컴파일 에러 없음.
+
+- [ ] **Step 9: 커밋 (`package-lock.json` 포함)**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+git add ai/superpowers/todo/frontend/package.json \
+        ai/superpowers/todo/frontend/package-lock.json \
+        ai/superpowers/todo/frontend/vite.config.ts \
+        ai/superpowers/todo/frontend/tsconfig.json \
+        ai/superpowers/todo/frontend/tsconfig.node.json \
+        ai/superpowers/todo/frontend/index.html \
+        ai/superpowers/todo/frontend/src/main.tsx \
+        ai/superpowers/todo/frontend/src/App.tsx \
+        ai/superpowers/todo/frontend/src/index.css \
+        ai/superpowers/todo/frontend/src/__tests__/setup.ts
+git commit -m "$(cat <<'EOF'
+[feat/todo-app] chore: Vite + React + TypeScript 프론트엔드 스캐폴드
+
+* /api/* → :8080 proxy 설정
+* Vitest + jsdom 테스트 환경 셋업
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 1: 도메인 모델
+
+### Task 1: `todo.go` — Priority, Todo, NewTodo, Patch, Validate, errors
+
+**Files:**
+- Create: `tutorials-go/ai/superpowers/todo/backend/todo/todo.go`
+- Create: `tutorials-go/ai/superpowers/todo/backend/todo/todo_test.go`
+
+- [ ] **Step 1: 실패 테스트 작성 — Priority.IsValid + Validate (제목 검증 + priority 검증 + dueDate)**
+
+`tutorials-go/ai/superpowers/todo/backend/todo/todo_test.go`:
+
+```go
+package todo
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPriority_IsValid(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		p    Priority
+		want bool
+	}{
+		{"low", PriorityLow, true},
+		{"medium", PriorityMedium, true},
+		{"high", PriorityHigh, true},
+		{"empty", Priority(""), false},
+		{"unknown", Priority("urgent"), false},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, tc.p.IsValid())
+		})
+	}
+}
+
+func TestNewTodo_Validate(t *testing.T) {
+	t.Parallel()
+	future := time.Now().Add(24 * time.Hour)
+	tooLong := ""
+	for i := 0; i < 201; i++ {
+		tooLong += "a"
+	}
+
+	tests := []struct {
+		name      string
+		input     NewTodo
+		wantField string // 빈 문자열이면 통과 기대
+	}{
+		{"title only", NewTodo{Title: "buy milk"}, ""},
+		{"title with priority", NewTodo{Title: "x", Priority: PriorityHigh}, ""},
+		{"title with future due", NewTodo{Title: "x", DueDate: &future}, ""},
+		{"empty title", NewTodo{Title: ""}, "title"},
+		{"whitespace title", NewTodo{Title: "   "}, "title"},
+		{"title length 201", NewTodo{Title: tooLong}, "title"},
+		{"invalid priority", NewTodo{Title: "x", Priority: Priority("urgent")}, "priority"},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.input.Validate()
+			if tc.wantField == "" {
+				assert.NoError(t, err)
+				return
+			}
+			var verr *ValidationError
+			if assert.ErrorAs(t, err, &verr) {
+				assert.Equal(t, tc.wantField, verr.Field)
+			}
+		})
+	}
+}
+
+func TestNewTodo_Validate_TitleLengthBoundaries(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		titleLen  int
+		wantValid bool
+	}{
+		{"len 1", 1, true},
+		{"len 200", 200, true},
+		{"len 0", 0, false},
+		{"len 201", 201, false},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			title := ""
+			for i := 0; i < tc.titleLen; i++ {
+				title += "a"
+			}
+			err := NewTodo{Title: title}.Validate()
+			if tc.wantValid {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+go test ./ai/superpowers/todo/backend/todo/...
+```
+
+Expected: 컴파일 에러 — `Priority`, `NewTodo`, `ValidationError` 등 미정의.
+
+- [ ] **Step 3: `todo.go` 최소 구현**
+
+`tutorials-go/ai/superpowers/todo/backend/todo/todo.go`:
+
+```go
+// Package todo defines the domain model and in-memory store for the
+// superpowers todo learning sample. The store is concurrency-safe via
+// sync.RWMutex, and the package exposes only value types so that
+// callers cannot mutate stored state through returned references.
+package todo
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Priority is the importance level of a todo item.
+type Priority string
+
+const (
+	PriorityLow    Priority = "low"
+	PriorityMedium Priority = "medium"
+	PriorityHigh   Priority = "high"
+)
+
+// IsValid reports whether p is one of the defined Priority constants.
+func (p Priority) IsValid() bool {
+	switch p {
+	case PriorityLow, PriorityMedium, PriorityHigh:
+		return true
+	default:
+		return false
+	}
+}
+
+// Todo is the domain entity. ID, CreatedAt, UpdatedAt are server-managed.
+type Todo struct {
+	ID        string     `json:"id"`
+	Title     string     `json:"title"`
+	Completed bool       `json:"completed"`
+	Priority  Priority   `json:"priority"`
+	DueDate   *time.Time `json:"dueDate"`
+	CreatedAt time.Time  `json:"createdAt"`
+	UpdatedAt time.Time  `json:"updatedAt"`
+}
+
+// NewTodo is the input type for Store.Add. Title is required.
+// Priority defaults to PriorityMedium when empty. DueDate is optional.
+type NewTodo struct {
+	Title    string
+	Priority Priority
+	DueDate  *time.Time
+}
+
+// Validate returns a *ValidationError when input is rejected, otherwise nil.
+// Title is trimmed before length check (1-200 chars).
+// Priority must be empty (defaulted later) or one of the defined constants.
+func (n NewTodo) Validate() error {
+	title := strings.TrimSpace(n.Title)
+	if title == "" {
+		return &ValidationError{Field: "title", Message: "title is required"}
+	}
+	if len(title) > 200 {
+		return &ValidationError{Field: "title", Message: "title must be at most 200 characters"}
+	}
+	if n.Priority != "" && !n.Priority.IsValid() {
+		return &ValidationError{Field: "priority", Message: fmt.Sprintf("priority %q is invalid", n.Priority)}
+	}
+	return nil
+}
+
+// Patch describes a partial update to a Todo.
+// A nil pointer means "field absent in request" (no change).
+// ClearDueDate true means the request explicitly set dueDate to null.
+type Patch struct {
+	Title        *string
+	Completed    *bool
+	Priority     *Priority
+	DueDate      *time.Time
+	ClearDueDate bool
+}
+
+// Validate returns *ValidationError when patch is invalid.
+// An empty patch (no fields set) is considered an error to match the API contract.
+func (p Patch) Validate() error {
+	if p.Title == nil && p.Completed == nil && p.Priority == nil && p.DueDate == nil && !p.ClearDueDate {
+		return &ValidationError{Field: "", Message: "request body must contain at least one field"}
+	}
+	if p.Title != nil {
+		t := strings.TrimSpace(*p.Title)
+		if t == "" {
+			return &ValidationError{Field: "title", Message: "title is required"}
+		}
+		if len(t) > 200 {
+			return &ValidationError{Field: "title", Message: "title must be at most 200 characters"}
+		}
+	}
+	if p.Priority != nil && !p.Priority.IsValid() {
+		return &ValidationError{Field: "priority", Message: fmt.Sprintf("priority %q is invalid", *p.Priority)}
+	}
+	return nil
+}
+
+// ValidationError indicates a field-level validation failure.
+// Field may be empty for whole-body errors.
+type ValidationError struct {
+	Field   string
+	Message string
+}
+
+// Error implements error.
+func (e *ValidationError) Error() string { return e.Message }
+
+// ErrNotFound is returned by Store.Update and Store.Delete when the id is unknown.
+var ErrNotFound = errors.New("todo not found")
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+go test -race ./ai/superpowers/todo/backend/todo/...
+```
+
+Expected: 모든 테스트 통과 (3개 부모 + 16개 subtest).
+
+- [ ] **Step 5: vet 확인**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+go vet ./ai/superpowers/todo/backend/todo/...
+```
+
+Expected: 출력 없음 (clean).
+
+- [ ] **Step 6: 커밋**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+git add ai/superpowers/todo/backend/todo/todo.go ai/superpowers/todo/backend/todo/todo_test.go
+git commit -m "$(cat <<'EOF'
+[feat/todo-app] feat: 도메인 모델 (Priority, Todo, NewTodo, Patch, Validate)
+
+* TDD: 검증 규칙을 표 기반 테스트로 먼저 작성
+* title trim 후 1~200자, priority enum, ValidationError, ErrNotFound
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 2: Store
+
+### Task 2.1: `store.go` — CRUD 기본 (Add / Get / Update / Delete)
+
+**Files:**
+- Create: `tutorials-go/ai/superpowers/todo/backend/todo/store.go`
+- Create: `tutorials-go/ai/superpowers/todo/backend/todo/store_test.go`
+
+- [ ] **Step 1: 실패 테스트 작성 — CRUD 시나리오**
+
+`tutorials-go/ai/superpowers/todo/backend/todo/store_test.go`:
+
+```go
+package todo
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	return NewStore()
+}
+
+func TestStore_Add_AssignsIDAndTimestamps(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	before := time.Now()
+	got := s.Add(NewTodo{Title: "buy milk"})
+	after := time.Now()
+
+	assert.NotEmpty(t, got.ID)
+	assert.Equal(t, "buy milk", got.Title)
+	assert.False(t, got.Completed)
+	assert.Equal(t, PriorityMedium, got.Priority, "default priority")
+	assert.Nil(t, got.DueDate)
+	assert.False(t, got.CreatedAt.Before(before))
+	assert.False(t, got.CreatedAt.After(after))
+	assert.Equal(t, got.CreatedAt, got.UpdatedAt)
+}
+
+func TestStore_Add_TrimsTitle(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	got := s.Add(NewTodo{Title: "  buy milk  "})
+	assert.Equal(t, "buy milk", got.Title)
+}
+
+func TestStore_Add_RespectsPriorityWhenProvided(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	got := s.Add(NewTodo{Title: "x", Priority: PriorityHigh})
+	assert.Equal(t, PriorityHigh, got.Priority)
+}
+
+func TestStore_Get_ReturnsCopy(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	added := s.Add(NewTodo{Title: "x"})
+	got, ok := s.Get(added.ID)
+	assert.True(t, ok)
+	assert.Equal(t, added, got)
+
+	got.Title = "mutated"
+	again, _ := s.Get(added.ID)
+	assert.Equal(t, "x", again.Title, "store copy must not be affected by external mutation")
+}
+
+func TestStore_Get_NotFound(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	_, ok := s.Get("nope")
+	assert.False(t, ok)
+}
+
+func TestStore_Update_PartialFields(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	added := s.Add(NewTodo{Title: "x"})
+	time.Sleep(time.Millisecond) // updatedAt 비교를 위한 1ms 차이
+
+	completed := true
+	newTitle := "y"
+	got, err := s.Update(added.ID, Patch{Title: &newTitle, Completed: &completed})
+	assert.NoError(t, err)
+	assert.Equal(t, "y", got.Title)
+	assert.True(t, got.Completed)
+	assert.True(t, got.UpdatedAt.After(added.UpdatedAt))
+	assert.Equal(t, added.CreatedAt, got.CreatedAt, "createdAt must not change")
+}
+
+func TestStore_Update_ClearDueDate(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	due := time.Now().Add(time.Hour)
+	added := s.Add(NewTodo{Title: "x", DueDate: &due})
+	got, err := s.Update(added.ID, Patch{ClearDueDate: true})
+	assert.NoError(t, err)
+	assert.Nil(t, got.DueDate)
+}
+
+func TestStore_Update_NotFound(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	completed := true
+	_, err := s.Update("nope", Patch{Completed: &completed})
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestStore_Update_ValidationError(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	added := s.Add(NewTodo{Title: "x"})
+	empty := ""
+	_, err := s.Update(added.ID, Patch{Title: &empty})
+	var verr *ValidationError
+	assert.ErrorAs(t, err, &verr)
+	assert.Equal(t, "title", verr.Field)
+}
+
+func TestStore_Delete_Success(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	added := s.Add(NewTodo{Title: "x"})
+	assert.NoError(t, s.Delete(added.ID))
+	_, ok := s.Get(added.ID)
+	assert.False(t, ok)
+}
+
+func TestStore_Delete_NotFound(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	assert.ErrorIs(t, s.Delete("nope"), ErrNotFound)
+}
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+go test ./ai/superpowers/todo/backend/todo/...
+```
+
+Expected: `Store`, `NewStore`, `Add`, `Get`, `Update`, `Delete` 미정의 컴파일 에러.
+
+- [ ] **Step 3: `store.go` CRUD 부분 구현**
+
+`tutorials-go/ai/superpowers/todo/backend/todo/store.go`:
+
+```go
+package todo
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Store is an in-memory, concurrency-safe collection of Todo values.
+// All read methods take an RLock; mutations take a Lock.
+// Returned values are copies — callers cannot affect stored state by mutation.
+type Store struct {
+	mu    sync.RWMutex
+	todos map[string]Todo
+}
+
+// NewStore creates an empty Store ready for use.
+func NewStore() *Store {
+	return &Store{todos: make(map[string]Todo)}
+}
+
+// Add validates input, assigns ID/timestamps, stores, and returns a copy.
+// Validation errors panic instead of returning — callers should validate first.
+// Add only assigns defaults; it does not call Validate. Use NewTodo.Validate() at the boundary.
+func (s *Store) Add(input NewTodo) Todo {
+	now := time.Now().UTC()
+	priority := input.Priority
+	if priority == "" {
+		priority = PriorityMedium
+	}
+	t := Todo{
+		ID:        uuid.NewString(),
+		Title:     strings.TrimSpace(input.Title),
+		Completed: false,
+		Priority:  priority,
+		DueDate:   input.DueDate,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	s.mu.Lock()
+	s.todos[t.ID] = t
+	s.mu.Unlock()
+	return t
+}
+
+// Get returns the todo with the given id and true, or zero value and false.
+func (s *Store) Get(id string) (Todo, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	t, ok := s.todos[id]
+	return t, ok
+}
+
+// Update applies the patch to the todo identified by id.
+// Returns ErrNotFound when id is unknown, or *ValidationError when patch is invalid.
+// Validates the patch before applying.
+func (s *Store) Update(id string, p Patch) (Todo, error) {
+	if err := p.Validate(); err != nil {
+		return Todo{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	t, ok := s.todos[id]
+	if !ok {
+		return Todo{}, ErrNotFound
+	}
+	if p.Title != nil {
+		t.Title = strings.TrimSpace(*p.Title)
+	}
+	if p.Completed != nil {
+		t.Completed = *p.Completed
+	}
+	if p.Priority != nil {
+		t.Priority = *p.Priority
+	}
+	if p.ClearDueDate {
+		t.DueDate = nil
+	} else if p.DueDate != nil {
+		t.DueDate = p.DueDate
+	}
+	t.UpdatedAt = time.Now().UTC()
+	s.todos[id] = t
+	return t, nil
+}
+
+// Delete removes the todo by id. Returns ErrNotFound when id is unknown.
+func (s *Store) Delete(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.todos[id]; !ok {
+		return ErrNotFound
+	}
+	delete(s.todos, id)
+	return nil
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+go test -race ./ai/superpowers/todo/backend/todo/...
+```
+
+Expected: Phase 1 + Phase 2.1 모든 테스트 통과.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+git add ai/superpowers/todo/backend/todo/store.go ai/superpowers/todo/backend/todo/store_test.go
+git commit -m "$(cat <<'EOF'
+[feat/todo-app] feat: in-memory Store CRUD (Add/Get/Update/Delete)
+
+* sync.RWMutex로 동시성 안전, 값 복사로 외부 mutation 차단
+* Update는 Patch 검증 후 부분 갱신, ClearDueDate로 null 명시 처리
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2.2: `store.go` — List 필터/정렬 + 동시성 검증
+
+**Files:**
+- Modify: `tutorials-go/ai/superpowers/todo/backend/todo/store.go`
+- Modify: `tutorials-go/ai/superpowers/todo/backend/todo/store_test.go`
+
+- [ ] **Step 1: 실패 테스트 추가 — List 필터/정렬/동시성**
+
+`store_test.go` 끝에 다음 코드 추가:
+
+```go
+func TestStore_List_FilterByStatus(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	a := s.Add(NewTodo{Title: "active"})
+	b := s.Add(NewTodo{Title: "done"})
+	completed := true
+	if _, err := s.Update(b.ID, Patch{Completed: &completed}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	_ = a
+
+	tests := []struct {
+		status   StatusFilter
+		wantLen  int
+		wantTitle string
+	}{
+		{StatusAll, 2, ""},
+		{StatusActive, 1, "active"},
+		{StatusCompleted, 1, "done"},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(string(tc.status), func(t *testing.T) {
+			t.Parallel()
+			got := s.List(Query{Status: tc.status})
+			assert.Len(t, got, tc.wantLen)
+			if tc.wantTitle != "" && len(got) == 1 {
+				assert.Equal(t, tc.wantTitle, got[0].Title)
+			}
+		})
+	}
+}
+
+func TestStore_List_SortByPriority(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	low := s.Add(NewTodo{Title: "low", Priority: PriorityLow})
+	high := s.Add(NewTodo{Title: "high", Priority: PriorityHigh})
+	mid := s.Add(NewTodo{Title: "mid", Priority: PriorityMedium})
+
+	asc := s.List(Query{Sort: SortPriority, Order: OrderAsc})
+	assert.Equal(t, []string{low.ID, mid.ID, high.ID}, ids(asc))
+
+	desc := s.List(Query{Sort: SortPriority, Order: OrderDesc})
+	assert.Equal(t, []string{high.ID, mid.ID, low.ID}, ids(desc))
+}
+
+func TestStore_List_SortByDueDate_NilLast(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	t1 := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	a := s.Add(NewTodo{Title: "a", DueDate: &t2})
+	b := s.Add(NewTodo{Title: "b", DueDate: nil})
+	c := s.Add(NewTodo{Title: "c", DueDate: &t1})
+
+	asc := s.List(Query{Sort: SortDueDate, Order: OrderAsc})
+	assert.Equal(t, []string{c.ID, a.ID, b.ID}, ids(asc), "nil dueDate must be last")
+
+	desc := s.List(Query{Sort: SortDueDate, Order: OrderDesc})
+	assert.Equal(t, []string{a.ID, c.ID, b.ID}, ids(desc), "nil dueDate must be last regardless of order")
+}
+
+func TestStore_List_SortByCreatedAt_DescDefault(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	first := s.Add(NewTodo{Title: "first"})
+	time.Sleep(time.Millisecond)
+	second := s.Add(NewTodo{Title: "second"})
+
+	desc := s.List(Query{}) // default sort=createdAt, order=desc
+	assert.Equal(t, []string{second.ID, first.ID}, ids(desc))
+}
+
+func TestStore_List_TieBreakByCreatedAtAsc(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	a := s.Add(NewTodo{Title: "a", Priority: PriorityHigh})
+	time.Sleep(time.Millisecond)
+	b := s.Add(NewTodo{Title: "b", Priority: PriorityHigh})
+
+	asc := s.List(Query{Sort: SortPriority, Order: OrderAsc})
+	assert.Equal(t, []string{a.ID, b.ID}, ids(asc))
+}
+
+func TestStore_ConcurrentAddList(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			s.Add(NewTodo{Title: "t"})
+		}(i)
+	}
+	done := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				_ = s.List(Query{})
+			}
+		}
+	}()
+	wg.Wait()
+	close(done)
+	assert.Len(t, s.List(Query{}), 100)
+}
+
+func ids(ts []Todo) []string {
+	out := make([]string, len(ts))
+	for i, t := range ts {
+		out[i] = t.ID
+	}
+	return out
+}
+```
+
+테스트 파일 상단 import에 `"sync"` 추가:
+
+```go
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+go test -race ./ai/superpowers/todo/backend/todo/...
+```
+
+Expected: `Query`, `StatusFilter`, `SortKey`, `OrderDir`, `s.List` 미정의 컴파일 에러.
+
+- [ ] **Step 3: `store.go`에 Query 타입 + List 구현 추가**
+
+`store.go` 끝에 다음 코드 추가:
+
+```go
+// StatusFilter narrows List results by completion state.
+type StatusFilter string
+
+const (
+	StatusAll       StatusFilter = "all"
+	StatusActive    StatusFilter = "active"
+	StatusCompleted StatusFilter = "completed"
+)
+
+// IsValid reports whether s is one of the defined StatusFilter constants.
+// Empty string is treated as StatusAll by callers and is not considered valid here.
+func (s StatusFilter) IsValid() bool {
+	switch s {
+	case StatusAll, StatusActive, StatusCompleted:
+		return true
+	default:
+		return false
+	}
+}
+
+// SortKey selects the field used to order List results.
+type SortKey string
+
+const (
+	SortCreatedAt SortKey = "createdAt"
+	SortDueDate   SortKey = "dueDate"
+	SortPriority  SortKey = "priority"
+)
+
+// IsValid reports whether k is one of the defined SortKey constants.
+func (k SortKey) IsValid() bool {
+	switch k {
+	case SortCreatedAt, SortDueDate, SortPriority:
+		return true
+	default:
+		return false
+	}
+}
+
+// OrderDir is ascending or descending.
+type OrderDir string
+
+const (
+	OrderAsc  OrderDir = "asc"
+	OrderDesc OrderDir = "desc"
+)
+
+// IsValid reports whether o is one of the defined OrderDir constants.
+func (o OrderDir) IsValid() bool {
+	switch o {
+	case OrderAsc, OrderDesc:
+		return true
+	default:
+		return false
+	}
+}
+
+// Query is the input to Store.List. Zero values mean defaults:
+// Status defaults to StatusAll, Sort to SortCreatedAt, Order to OrderDesc.
+type Query struct {
+	Status StatusFilter
+	Sort   SortKey
+	Order  OrderDir
+}
+
+// List returns todos matching the query, sorted as requested.
+// nil dueDate values are placed last regardless of Order.
+// Tie-breaks fall back to createdAt ascending for determinism.
+func (s *Store) List(q Query) []Todo {
+	q = q.withDefaults()
+	s.mu.RLock()
+	out := make([]Todo, 0, len(s.todos))
+	for _, t := range s.todos {
+		if !matchesStatus(t, q.Status) {
+			continue
+		}
+		out = append(out, t)
+	}
+	s.mu.RUnlock()
+	sortTodos(out, q.Sort, q.Order)
+	return out
+}
+
+func (q Query) withDefaults() Query {
+	if q.Status == "" {
+		q.Status = StatusAll
+	}
+	if q.Sort == "" {
+		q.Sort = SortCreatedAt
+	}
+	if q.Order == "" {
+		q.Order = OrderDesc
+	}
+	return q
+}
+
+func matchesStatus(t Todo, f StatusFilter) bool {
+	switch f {
+	case StatusActive:
+		return !t.Completed
+	case StatusCompleted:
+		return t.Completed
+	default:
+		return true
+	}
+}
+
+// sortTodos sorts ts in place by the given key/order.
+// nil dueDate values always sort last regardless of order (deterministic).
+// Tie-breaks fall back to createdAt ascending (stable sort).
+func sortTodos(ts []Todo, key SortKey, order OrderDir) {
+	asc := order == OrderAsc
+	sort.SliceStable(ts, func(i, j int) bool {
+		a, b := ts[i], ts[j]
+
+		// dueDate 정렬: nil은 항상 마지막 (asc/desc 무관)
+		if key == SortDueDate {
+			if a.DueDate == nil && b.DueDate == nil {
+				return a.CreatedAt.Before(b.CreatedAt)
+			}
+			if a.DueDate == nil {
+				return false
+			}
+			if b.DueDate == nil {
+				return true
+			}
+		}
+
+		cmp := primaryCompare(a, b, key)
+		if cmp == 0 {
+			return a.CreatedAt.Before(b.CreatedAt) // tie-break: createdAt asc
+		}
+		if asc {
+			return cmp < 0
+		}
+		return cmp > 0
+	})
+}
+
+func primaryCompare(a, b Todo, key SortKey) int {
+	switch key {
+	case SortPriority:
+		return priorityRank(a.Priority) - priorityRank(b.Priority)
+	case SortDueDate:
+		return compareTime(*a.DueDate, *b.DueDate) // 호출 시점에 둘 다 non-nil 보장됨 (sortTodos에서 분기)
+	default: // SortCreatedAt
+		return compareTime(a.CreatedAt, b.CreatedAt)
+	}
+}
+
+func priorityRank(p Priority) int {
+	switch p {
+	case PriorityLow:
+		return 1
+	case PriorityMedium:
+		return 2
+	case PriorityHigh:
+		return 3
+	default:
+		return 0
+	}
+}
+
+func compareTime(a, b time.Time) int {
+	if a.Before(b) {
+		return -1
+	}
+	if a.After(b) {
+		return 1
+	}
+	return 0
+}
+```
+
+`store.go` 상단 import에 `"sort"` 추가:
+
+```go
+import (
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+go test -race ./ai/superpowers/todo/backend/todo/...
+```
+
+Expected: Phase 2.2 추가 테스트 모두 통과. `-race` 플래그로 동시성 테스트도 통과.
+
+- [ ] **Step 5: vet 확인**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+go vet ./ai/superpowers/todo/backend/todo/...
+```
+
+Expected: 출력 없음.
+
+- [ ] **Step 6: 커밋**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+git add ai/superpowers/todo/backend/todo/store.go ai/superpowers/todo/backend/todo/store_test.go
+git commit -m "$(cat <<'EOF'
+[feat/todo-app] feat: Store List 필터/정렬 + 동시성 안전 검증
+
+* Query (Status/Sort/Order) 타입 추가
+* dueDate nil은 항상 마지막, createdAt asc 안정 tie-break
+* 100 goroutine 동시 Add+List race 테스트 통과
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 3: Handler
+
+### Task 3.1: `handler.go` — Handler 구조 + Create + Delete + writeError
+
+**Files:**
+- Create: `tutorials-go/ai/superpowers/todo/backend/todo/handler.go`
+- Create: `tutorials-go/ai/superpowers/todo/backend/todo/handler_test.go`
+
+- [ ] **Step 1: 실패 테스트 작성 — Create + Delete + 에러 매핑**
+
+`tutorials-go/ai/superpowers/todo/backend/todo/handler_test.go`:
+
+```go
+package todo
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestHandler(t *testing.T) (*Handler, *Store) {
+	t.Helper()
+	s := NewStore()
+	return NewHandler(s), s
+}
+
+func newJSONRequest(method, path, body string) (*echo.Echo, echo.Context, *httptest.ResponseRecorder) {
+	e := echo.New()
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	return e, c, rec
+}
+
+func TestHandler_Create_Returns201WithBody(t *testing.T) {
+	t.Parallel()
+	h, _ := newTestHandler(t)
+	_, c, rec := newJSONRequest(http.MethodPost, "/api/todos", `{"title":"buy milk"}`)
+	assert.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusCreated, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"title":"buy milk"`)
+	assert.Contains(t, rec.Body.String(), `"priority":"medium"`)
+}
+
+func TestHandler_Create_Returns400OnEmptyTitle(t *testing.T) {
+	t.Parallel()
+	h, _ := newTestHandler(t)
+	_, c, rec := newJSONRequest(http.MethodPost, "/api/todos", `{"title":"  "}`)
+	assert.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"code":"validation_failed"`)
+	assert.Contains(t, rec.Body.String(), `"field":"title"`)
+}
+
+func TestHandler_Create_Returns400OnInvalidJSON(t *testing.T) {
+	t.Parallel()
+	h, _ := newTestHandler(t)
+	_, c, rec := newJSONRequest(http.MethodPost, "/api/todos", `{not json`)
+	assert.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"code":"invalid_json"`)
+}
+
+func TestHandler_Delete_Returns204(t *testing.T) {
+	t.Parallel()
+	h, s := newTestHandler(t)
+	added := s.Add(NewTodo{Title: "x"})
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodDelete, "/api/todos/"+added.ID, nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(added.ID)
+
+	assert.NoError(t, h.Delete(c))
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	_, ok := s.Get(added.ID)
+	assert.False(t, ok)
+}
+
+func TestHandler_Delete_Returns404OnUnknownID(t *testing.T) {
+	t.Parallel()
+	h, _ := newTestHandler(t)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodDelete, "/api/todos/nope", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("nope")
+
+	assert.NoError(t, h.Delete(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"code":"not_found"`)
+}
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+go test ./ai/superpowers/todo/backend/todo/...
+```
+
+Expected: `Handler`, `NewHandler`, `Create`, `Delete` 미정의 컴파일 에러.
+
+- [ ] **Step 3: `handler.go` 최소 구현**
+
+`tutorials-go/ai/superpowers/todo/backend/todo/handler.go`:
+
+```go
+package todo
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+// Handler exposes the todo store as JSON HTTP endpoints.
+// It is responsible for HTTP I/O concerns only — parsing, validation
+// shape, status code mapping. Domain logic lives in Store.
+type Handler struct {
+	store *Store
+}
+
+// NewHandler returns a Handler bound to the given store.
+func NewHandler(s *Store) *Handler {
+	return &Handler{store: s}
+}
+
+// Create handles POST /api/todos.
+// Body: { "title": "...", "priority"?: "...", "dueDate"?: "RFC3339" }.
+// Returns 201 with the created Todo, or 400 on validation/JSON errors.
+func (h *Handler) Create(c echo.Context) error {
+	var body createBody
+	if err := json.NewDecoder(c.Request().Body).Decode(&body); err != nil {
+		return c.JSON(http.StatusBadRequest, errBody("invalid_json", "request body is not valid JSON", nil))
+	}
+	input := NewTodo{
+		Title:    body.Title,
+		Priority: Priority(body.Priority),
+		DueDate:  body.DueDate,
+	}
+	if err := input.Validate(); err != nil {
+		return writeError(c, err)
+	}
+	created := h.store.Add(input)
+	return c.JSON(http.StatusCreated, created)
+}
+
+// Delete handles DELETE /api/todos/{id}.
+// Returns 204 on success or 404 when the id is unknown.
+func (h *Handler) Delete(c echo.Context) error {
+	id := c.Param("id")
+	if err := h.store.Delete(id); err != nil {
+		return writeError(c, err)
+	}
+	return c.NoContent(http.StatusNoContent)
+}
+
+type createBody struct {
+	Title    string  `json:"title"`
+	Priority string  `json:"priority"`
+	DueDate  *time.Time `json:"dueDate"`
+}
+
+// errBody builds the standard error envelope { "error": { code, message, details? } }.
+func errBody(code, msg string, details map[string]any) echo.Map {
+	body := echo.Map{"code": code, "message": msg}
+	if details != nil {
+		body["details"] = details
+	}
+	return echo.Map{"error": body}
+}
+
+// writeError maps domain errors to JSON error responses with appropriate HTTP status codes.
+func writeError(c echo.Context, err error) error {
+	var verr *ValidationError
+	switch {
+	case errors.As(err, &verr):
+		details := map[string]any{}
+		if verr.Field != "" {
+			details["field"] = verr.Field
+		}
+		if len(details) == 0 {
+			details = nil
+		}
+		return c.JSON(http.StatusBadRequest, errBody("validation_failed", verr.Message, details))
+	case errors.Is(err, ErrNotFound):
+		return c.JSON(http.StatusNotFound, errBody("not_found", err.Error(), nil))
+	default:
+		c.Logger().Error(err)
+		return c.JSON(http.StatusInternalServerError, errBody("internal_error", "internal server error", nil))
+	}
+}
+```
+
+위 코드의 `createBody`에 `time.Time` import 추가가 필요. 파일 상단 import 블록에 `"time"` 추가:
+
+```go
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+go test -race ./ai/superpowers/todo/backend/todo/...
+```
+
+Expected: Phase 1, 2, 3.1 테스트 모두 통과.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+git add ai/superpowers/todo/backend/todo/handler.go ai/superpowers/todo/backend/todo/handler_test.go
+git commit -m "$(cat <<'EOF'
+[feat/todo-app] feat: Handler 구조 + Create/Delete + writeError
+
+* writeError가 ValidationError → 400, ErrNotFound → 404, 그 외 → 500 매핑
+* errBody 헬퍼로 표준 에러 envelope { error: {code, message, details?} } 생성
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3.2: `handler.go` — List + 쿼리 파라미터 검증
+
+**Files:**
+- Modify: `tutorials-go/ai/superpowers/todo/backend/todo/handler.go`
+- Modify: `tutorials-go/ai/superpowers/todo/backend/todo/handler_test.go`
+
+- [ ] **Step 1: 실패 테스트 추가 — List 정상 + 잘못된 쿼리 파라미터**
+
+`handler_test.go` 끝에 추가:
+
+```go
+func TestHandler_List_Defaults(t *testing.T) {
+	t.Parallel()
+	h, s := newTestHandler(t)
+	s.Add(NewTodo{Title: "first"})
+	s.Add(NewTodo{Title: "second"})
+
+	_, c, rec := newJSONRequest(http.MethodGet, "/api/todos", "")
+	assert.NoError(t, h.List(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	// JSON array of length 2
+	body := rec.Body.String()
+	assert.Contains(t, body, `"title":"first"`)
+	assert.Contains(t, body, `"title":"second"`)
+	assert.True(t, strings.HasPrefix(strings.TrimSpace(body), "["))
+}
+
+func TestHandler_List_FilterAndSort(t *testing.T) {
+	t.Parallel()
+	h, s := newTestHandler(t)
+	a := s.Add(NewTodo{Title: "active"})
+	b := s.Add(NewTodo{Title: "done"})
+	completed := true
+	if _, err := s.Update(b.ID, Patch{Completed: &completed}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	_ = a
+
+	_, c, rec := newJSONRequest(http.MethodGet, "/api/todos?status=active", "")
+	assert.NoError(t, h.List(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+	assert.Contains(t, body, `"title":"active"`)
+	assert.NotContains(t, body, `"title":"done"`)
+}
+
+func TestHandler_List_InvalidQueryParam(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{"bad status", "status=invalid"},
+		{"bad sort", "sort=garbage"},
+		{"bad order", "order=sideways"},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			h, _ := newTestHandler(t)
+			_, c, rec := newJSONRequest(http.MethodGet, "/api/todos?"+tc.query, "")
+			assert.NoError(t, h.List(c))
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+			assert.Contains(t, rec.Body.String(), `"code":"validation_failed"`)
+		})
+	}
+}
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+go test ./ai/superpowers/todo/backend/todo/...
+```
+
+Expected: `h.List` 미정의 컴파일 에러.
+
+- [ ] **Step 3: `handler.go`에 List 추가**
+
+`handler.go`에 다음 메서드 추가 (Create 위/아래 어디든 OK):
+
+```go
+// List handles GET /api/todos with optional status/sort/order query params.
+// Empty params apply defaults (status=all, sort=createdAt, order=desc).
+func (h *Handler) List(c echo.Context) error {
+	q, err := parseQuery(c)
+	if err != nil {
+		return writeError(c, err)
+	}
+	return c.JSON(http.StatusOK, h.store.List(q))
+}
+
+func parseQuery(c echo.Context) (Query, error) {
+	q := Query{}
+	if v := c.QueryParam("status"); v != "" {
+		s := StatusFilter(v)
+		if !s.IsValid() {
+			return Query{}, &ValidationError{Field: "status", Message: "status must be one of: all, active, completed"}
+		}
+		q.Status = s
+	}
+	if v := c.QueryParam("sort"); v != "" {
+		s := SortKey(v)
+		if !s.IsValid() {
+			return Query{}, &ValidationError{Field: "sort", Message: "sort must be one of: createdAt, dueDate, priority"}
+		}
+		q.Sort = s
+	}
+	if v := c.QueryParam("order"); v != "" {
+		o := OrderDir(v)
+		if !o.IsValid() {
+			return Query{}, &ValidationError{Field: "order", Message: "order must be one of: asc, desc"}
+		}
+		q.Order = o
+	}
+	return q, nil
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+go test -race ./ai/superpowers/todo/backend/todo/...
+```
+
+Expected: 모든 테스트 통과.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+git add ai/superpowers/todo/backend/todo/handler.go ai/superpowers/todo/backend/todo/handler_test.go
+git commit -m "$(cat <<'EOF'
+[feat/todo-app] feat: Handler.List + 쿼리 파라미터 검증
+
+* status/sort/order는 부재 시 기본값, 잘못된 값은 400 validation_failed
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3.3: `handler.go` — Update (PATCH 의미론)
+
+**Files:**
+- Modify: `tutorials-go/ai/superpowers/todo/backend/todo/handler.go`
+- Modify: `tutorials-go/ai/superpowers/todo/backend/todo/handler_test.go`
+
+- [ ] **Step 1: 실패 테스트 추가 — PATCH 의미론 (table-driven)**
+
+`handler_test.go` 끝에 추가:
+
+```go
+func TestHandler_Update_PatchSemantics(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		body        string
+		wantStatus  int
+		wantInBody  string
+		notInBody   string
+		wantField   string
+	}{
+		{
+			name:       "completed only",
+			body:       `{"completed":true}`,
+			wantStatus: http.StatusOK,
+			wantInBody: `"completed":true`,
+		},
+		{
+			name:       "clear duedate",
+			body:       `{"dueDate":null}`,
+			wantStatus: http.StatusOK,
+			wantInBody: `"dueDate":null`,
+		},
+		{
+			name:       "set duedate",
+			body:       `{"dueDate":"2026-05-15T18:00:00Z"}`,
+			wantStatus: http.StatusOK,
+			wantInBody: `"dueDate":"2026-05-15T18:00:00Z"`,
+		},
+		{
+			name:       "title only",
+			body:       `{"title":"updated"}`,
+			wantStatus: http.StatusOK,
+			wantInBody: `"title":"updated"`,
+		},
+		{
+			name:       "priority only",
+			body:       `{"priority":"high"}`,
+			wantStatus: http.StatusOK,
+			wantInBody: `"priority":"high"`,
+		},
+		{
+			name:       "empty body",
+			body:       `{}`,
+			wantStatus: http.StatusBadRequest,
+			wantInBody: `"validation_failed"`,
+		},
+		{
+			name:       "title null rejected",
+			body:       `{"title":null}`,
+			wantStatus: http.StatusBadRequest,
+			wantInBody: `"validation_failed"`,
+			wantField:  "title",
+		},
+		{
+			name:       "completed null rejected",
+			body:       `{"completed":null}`,
+			wantStatus: http.StatusBadRequest,
+			wantInBody: `"validation_failed"`,
+			wantField:  "completed",
+		},
+		{
+			name:       "priority null rejected",
+			body:       `{"priority":null}`,
+			wantStatus: http.StatusBadRequest,
+			wantInBody: `"validation_failed"`,
+			wantField:  "priority",
+		},
+		{
+			name:       "invalid priority",
+			body:       `{"priority":"urgent"}`,
+			wantStatus: http.StatusBadRequest,
+			wantInBody: `"validation_failed"`,
+			wantField:  "priority",
+		},
+		{
+			name:       "bad duedate string",
+			body:       `{"dueDate":"not-a-date"}`,
+			wantStatus: http.StatusBadRequest,
+			wantInBody: `"validation_failed"`,
+			wantField:  "dueDate",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			h, s := newTestHandler(t)
+			added := s.Add(NewTodo{Title: "x"})
+
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPatch, "/api/todos/"+added.ID, strings.NewReader(tc.body))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetParamNames("id")
+			c.SetParamValues(added.ID)
+
+			assert.NoError(t, h.Update(c))
+			assert.Equal(t, tc.wantStatus, rec.Code, "body: %s", rec.Body.String())
+			assert.Contains(t, rec.Body.String(), tc.wantInBody)
+			if tc.wantField != "" {
+				assert.Contains(t, rec.Body.String(), `"field":"`+tc.wantField+`"`)
+			}
+		})
+	}
+}
+
+func TestHandler_Update_NotFound(t *testing.T) {
+	t.Parallel()
+	h, _ := newTestHandler(t)
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPatch, "/api/todos/nope", strings.NewReader(`{"completed":true}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("nope")
+
+	assert.NoError(t, h.Update(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"code":"not_found"`)
+}
+
+func TestHandler_Update_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	h, s := newTestHandler(t)
+	added := s.Add(NewTodo{Title: "x"})
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPatch, "/api/todos/"+added.ID, strings.NewReader(`{not json`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(added.ID)
+
+	assert.NoError(t, h.Update(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"code":"invalid_json"`)
+}
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+go test ./ai/superpowers/todo/backend/todo/...
+```
+
+Expected: `h.Update` 미정의.
+
+- [ ] **Step 3: `handler.go`에 Update + parsePatch 추가**
+
+먼저 `handler.go` 상단 import 블록에 `"bytes"`를 추가:
+
+```go
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+```
+
+`handler.go`에 다음 추가:
+
+```go
+// Update handles PATCH /api/todos/{id}. The body must be a non-empty JSON object.
+// Only dueDate accepts JSON null (clears the value); other fields with null are rejected.
+func (h *Handler) Update(c echo.Context) error {
+	patch, err := parsePatch(c)
+	if err != nil {
+		return writeError(c, err)
+	}
+	id := c.Param("id")
+	updated, err := h.store.Update(id, patch)
+	if err != nil {
+		return writeError(c, err)
+	}
+	return c.JSON(http.StatusOK, updated)
+}
+
+func parsePatch(c echo.Context) (Patch, error) {
+	var raw map[string]json.RawMessage
+	if err := json.NewDecoder(c.Request().Body).Decode(&raw); err != nil {
+		return Patch{}, &jsonDecodeError{}
+	}
+
+	patch := Patch{}
+
+	if v, ok := raw["title"]; ok {
+		if isJSONNull(v) {
+			return Patch{}, &ValidationError{Field: "title", Message: "title cannot be null"}
+		}
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return Patch{}, &ValidationError{Field: "title", Message: "title must be a string"}
+		}
+		patch.Title = &s
+	}
+	if v, ok := raw["completed"]; ok {
+		if isJSONNull(v) {
+			return Patch{}, &ValidationError{Field: "completed", Message: "completed cannot be null"}
+		}
+		var b bool
+		if err := json.Unmarshal(v, &b); err != nil {
+			return Patch{}, &ValidationError{Field: "completed", Message: "completed must be a boolean"}
+		}
+		patch.Completed = &b
+	}
+	if v, ok := raw["priority"]; ok {
+		if isJSONNull(v) {
+			return Patch{}, &ValidationError{Field: "priority", Message: "priority cannot be null"}
+		}
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return Patch{}, &ValidationError{Field: "priority", Message: "priority must be a string"}
+		}
+		p := Priority(s)
+		patch.Priority = &p
+	}
+	if v, ok := raw["dueDate"]; ok {
+		if isJSONNull(v) {
+			patch.ClearDueDate = true
+		} else {
+			var t time.Time
+			if err := json.Unmarshal(v, &t); err != nil {
+				return Patch{}, &ValidationError{Field: "dueDate", Message: "dueDate must be RFC3339 timestamp or null"}
+			}
+			patch.DueDate = &t
+		}
+	}
+	return patch, nil
+}
+
+// isJSONNull reports whether the raw message is the literal "null" (modulo whitespace).
+// json.RawMessage may carry surrounding whitespace from the original document.
+func isJSONNull(b json.RawMessage) bool {
+	return string(bytes.TrimSpace(b)) == "null"
+}
+
+// jsonDecodeError wraps JSON parse failures so writeError emits invalid_json instead of validation_failed.
+type jsonDecodeError struct{}
+
+func (jsonDecodeError) Error() string { return "invalid_json" }
+```
+
+`writeError`도 jsonDecodeError를 처리하도록 수정:
+
+```go
+func writeError(c echo.Context, err error) error {
+	var verr *ValidationError
+	switch {
+	case errors.As(err, new(*jsonDecodeError)):
+		return c.JSON(http.StatusBadRequest, errBody("invalid_json", "request body is not valid JSON", nil))
+	case errors.As(err, &verr):
+		details := map[string]any{}
+		if verr.Field != "" {
+			details["field"] = verr.Field
+		}
+		if len(details) == 0 {
+			details = nil
+		}
+		return c.JSON(http.StatusBadRequest, errBody("validation_failed", verr.Message, details))
+	case errors.Is(err, ErrNotFound):
+		return c.JSON(http.StatusNotFound, errBody("not_found", err.Error(), nil))
+	default:
+		c.Logger().Error(err)
+		return c.JSON(http.StatusInternalServerError, errBody("internal_error", "internal server error", nil))
+	}
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+go test -race ./ai/superpowers/todo/backend/todo/...
+```
+
+Expected: 모든 테스트 통과.
+
+- [ ] **Step 5: vet 확인**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+go vet ./ai/superpowers/todo/backend/todo/...
+```
+
+Expected: 출력 없음.
+
+- [ ] **Step 6: 커밋**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+git add ai/superpowers/todo/backend/todo/handler.go ai/superpowers/todo/backend/todo/handler_test.go
+git commit -m "$(cat <<'EOF'
+[feat/todo-app] feat: Handler.Update + PATCH 의미론 (null/null-rejected/clearDueDate)
+
+* map[string]json.RawMessage로 키 존재 여부 검출 후 필드별 unmarshal
+* dueDate만 null 허용(클리어), 나머지 필드 null은 400 validation_failed
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 4: Server 통합
+
+### Task 4: `server.go` + `main.go` 통합 + httptest 통합 테스트
+
+**Files:**
+- Create: `tutorials-go/ai/superpowers/todo/backend/server/server.go`
+- Create: `tutorials-go/ai/superpowers/todo/backend/server/server_test.go`
+
+- [ ] **Step 1: 통합 테스트 작성 (실패 예상)**
+
+`tutorials-go/ai/superpowers/todo/backend/server/server_test.go`:
+
+```go
+package server_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kenshin579/tutorials-go/ai/superpowers/todo/backend/server"
+	"github.com/kenshin579/tutorials-go/ai/superpowers/todo/backend/todo"
+)
+
+func setupServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	s := todo.NewStore()
+	e := server.New(s)
+	ts := httptest.NewServer(e)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestServer_Health(t *testing.T) {
+	t.Parallel()
+	ts := setupServer(t)
+
+	resp, err := http.Get(ts.URL + "/api/health")
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body map[string]string
+	assert.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, "ok", body["status"])
+}
+
+func TestServer_CRUDLifecycle(t *testing.T) {
+	t.Parallel()
+	ts := setupServer(t)
+
+	// 1. Create
+	create := bytes.NewBufferString(`{"title":"buy milk","priority":"high"}`)
+	resp, err := http.Post(ts.URL+"/api/todos", "application/json", create)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	var created todo.Todo
+	assert.NoError(t, json.NewDecoder(resp.Body).Decode(&created))
+	assert.NotEmpty(t, created.ID)
+	assert.Equal(t, "buy milk", created.Title)
+
+	// 2. List
+	resp, err = http.Get(ts.URL + "/api/todos")
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	var list []todo.Todo
+	assert.NoError(t, json.NewDecoder(resp.Body).Decode(&list))
+	assert.Len(t, list, 1)
+
+	// 3. Update (toggle complete)
+	patch := bytes.NewBufferString(`{"completed":true}`)
+	req, _ := http.NewRequest(http.MethodPatch, ts.URL+"/api/todos/"+created.ID, patch)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = http.DefaultClient.Do(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	var updated todo.Todo
+	assert.NoError(t, json.NewDecoder(resp.Body).Decode(&updated))
+	assert.True(t, updated.Completed)
+
+	// 4. Delete
+	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/api/todos/"+created.ID, nil)
+	resp, err = http.DefaultClient.Do(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	// 5. List again — should be empty
+	resp, err = http.Get(ts.URL + "/api/todos")
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, "[]\n", string(body))
+}
+
+func TestServer_CORSPreflight(t *testing.T) {
+	t.Parallel()
+	ts := setupServer(t)
+
+	req, _ := http.NewRequest(http.MethodOptions, ts.URL+"/api/todos", nil)
+	req.Header.Set("Origin", "http://localhost:5173")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	resp, err := http.DefaultClient.Do(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Contains(t, resp.Header.Get("Access-Control-Allow-Origin"), "http://localhost:5173")
+}
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+go test ./ai/superpowers/todo/backend/server/...
+```
+
+Expected: `server.New` 미정의.
+
+- [ ] **Step 3: `server.go` 구현**
+
+`tutorials-go/ai/superpowers/todo/backend/server/server.go`:
+
+```go
+// Package server wires the Echo HTTP server with middleware and route registration.
+// It is intentionally domain-agnostic — domain logic is in the todo package.
+package server
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+
+	"github.com/kenshin579/tutorials-go/ai/superpowers/todo/backend/todo"
+)
+
+// New constructs a configured *echo.Echo bound to the given store.
+// Middleware order: Recover → Logger → CORS. CORS allows the Vite dev/preview origins.
+func New(store *todo.Store) *echo.Echo {
+	e := echo.New()
+	e.HideBanner = true
+	e.HidePort = true
+
+	e.Use(middleware.Recover())
+	e.Use(middleware.Logger())
+	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
+		AllowOrigins: []string{"http://localhost:5173", "http://localhost:4173"},
+		AllowMethods: []string{http.MethodGet, http.MethodPost, http.MethodPatch, http.MethodDelete, http.MethodOptions},
+	}))
+
+	h := todo.NewHandler(store)
+
+	e.GET("/api/health", func(c echo.Context) error {
+		return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
+	})
+	e.GET("/api/todos", h.List)
+	e.POST("/api/todos", h.Create)
+	e.PATCH("/api/todos/:id", h.Update)
+	e.DELETE("/api/todos/:id", h.Delete)
+
+	return e
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+go test -race ./ai/superpowers/todo/backend/...
+```
+
+Expected: server + todo 패키지 모든 테스트 통과.
+
+- [ ] **Step 5: 백엔드 부팅 검증**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go/ai/superpowers/todo/backend
+go run . &
+sleep 1
+curl -s http://localhost:8080/api/health
+curl -s -X POST -H "Content-Type: application/json" -d '{"title":"hello"}' http://localhost:8080/api/todos
+curl -s http://localhost:8080/api/todos
+kill %1 2>/dev/null
+```
+
+Expected: 헬스체크 `{"status":"ok"}`, POST 결과 + 목록 결과 출력.
+
+- [ ] **Step 6: vet 확인**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+go vet ./ai/superpowers/todo/backend/...
+```
+
+Expected: 출력 없음.
+
+- [ ] **Step 7: 커밋**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+git add ai/superpowers/todo/backend/server/server.go ai/superpowers/todo/backend/server/server_test.go
+git commit -m "$(cat <<'EOF'
+[feat/todo-app] feat: Echo 서버 통합 (라우팅, 미들웨어, CORS) + httptest 통합 테스트
+
+* Recover, Logger, CORS(:5173, :4173) 미들웨어
+* /api/health + Todo CRUD 엔드포인트 등록
+* CRUD lifecycle + CORS preflight 통합 테스트
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 5: 프론트엔드 인프라
+
+### Task 5: `types.ts` + `api.ts` + MSW 셋업
+
+**Files:**
+- Create: `tutorials-go/ai/superpowers/todo/frontend/src/types.ts`
+- Create: `tutorials-go/ai/superpowers/todo/frontend/src/api.ts`
+- Create: `tutorials-go/ai/superpowers/todo/frontend/src/__tests__/mocks/handlers.ts`
+- Create: `tutorials-go/ai/superpowers/todo/frontend/src/__tests__/mocks/server.ts`
+- Modify: `tutorials-go/ai/superpowers/todo/frontend/src/__tests__/setup.ts`
+
+- [ ] **Step 1: `types.ts` — 백엔드 JSON 모델과 동기화**
+
+`tutorials-go/ai/superpowers/todo/frontend/src/types.ts`:
+
+```ts
+// 본 파일은 backend/todo/todo.go와 수동 동기화한다.
+// BE 모델 변경 시 같이 수정 (CLAUDE.md 정책).
+
+export type Priority = 'low' | 'medium' | 'high'
+
+export type Status = 'all' | 'active' | 'completed'
+
+export type SortKey = 'createdAt' | 'dueDate' | 'priority'
+
+export type Order = 'asc' | 'desc'
+
+export interface Todo {
+  id: string
+  title: string
+  completed: boolean
+  priority: Priority
+  dueDate: string | null // RFC3339 또는 null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface NewTodo {
+  title: string
+  priority?: Priority
+  dueDate?: string | null
+}
+
+export interface Patch {
+  title?: string
+  completed?: boolean
+  priority?: Priority
+  dueDate?: string | null // null이면 명시적 클리어
+}
+
+export interface Query {
+  status: Status
+  sort: SortKey
+  order: Order
+}
+```
+
+- [ ] **Step 2: `api.ts` — 타입 안전 fetch wrapper**
+
+`tutorials-go/ai/superpowers/todo/frontend/src/api.ts`:
+
+```ts
+import type { NewTodo, Patch, Query, Todo } from './types'
+
+const BASE = '/api'
+
+export class ApiError extends Error {
+  constructor(public code: string, message: string) {
+    super(message)
+    this.name = 'ApiError'
+  }
+}
+
+async function call<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(BASE + path, {
+    ...init,
+    headers: { 'Content-Type': 'application/json', ...(init?.headers ?? {}) },
+  })
+  if (!res.ok) {
+    let code = 'unknown'
+    let message = res.statusText
+    try {
+      const body = (await res.json()) as { error?: { code?: string; message?: string } }
+      code = body.error?.code ?? code
+      message = body.error?.message ?? message
+    } catch {
+      // body가 JSON이 아닐 수 있음. statusText 그대로 사용.
+    }
+    throw new ApiError(code, message)
+  }
+  if (res.status === 204) return undefined as T
+  return (await res.json()) as T
+}
+
+export const api = {
+  list: (q: Query) =>
+    call<Todo[]>(`/todos?${new URLSearchParams(q as unknown as Record<string, string>)}`),
+  create: (input: NewTodo) =>
+    call<Todo>('/todos', { method: 'POST', body: JSON.stringify(input) }),
+  update: (id: string, patch: Patch) =>
+    call<Todo>(`/todos/${id}`, { method: 'PATCH', body: JSON.stringify(patch) }),
+  remove: (id: string) =>
+    call<void>(`/todos/${id}`, { method: 'DELETE' }),
+}
+```
+
+- [ ] **Step 3: MSW 핸들러 작성 (in-memory store 흉내)**
+
+`tutorials-go/ai/superpowers/todo/frontend/src/__tests__/mocks/handlers.ts`:
+
+```ts
+import { http, HttpResponse } from 'msw'
+import type { Todo, NewTodo, Patch } from '../../types'
+
+let todos: Todo[] = []
+
+function uid(): string {
+  return Math.random().toString(36).slice(2) + Date.now().toString(36)
+}
+
+export function resetMockTodos(seed: Todo[] = []) {
+  todos = seed.map((t) => ({ ...t }))
+}
+
+export const handlers = [
+  http.get('/api/health', () => HttpResponse.json({ status: 'ok' })),
+
+  http.get('/api/todos', ({ request }) => {
+    const url = new URL(request.url)
+    const status = url.searchParams.get('status') ?? 'all'
+    let out = [...todos]
+    if (status === 'active') out = out.filter((t) => !t.completed)
+    if (status === 'completed') out = out.filter((t) => t.completed)
+    return HttpResponse.json(out)
+  }),
+
+  http.post('/api/todos', async ({ request }) => {
+    const body = (await request.json()) as NewTodo
+    if (!body.title?.trim()) {
+      return HttpResponse.json(
+        { error: { code: 'validation_failed', message: 'title is required', details: { field: 'title' } } },
+        { status: 400 },
+      )
+    }
+    const now = new Date().toISOString()
+    const created: Todo = {
+      id: uid(),
+      title: body.title.trim(),
+      completed: false,
+      priority: body.priority ?? 'medium',
+      dueDate: body.dueDate ?? null,
+      createdAt: now,
+      updatedAt: now,
+    }
+    todos.push(created)
+    return HttpResponse.json(created, { status: 201 })
+  }),
+
+  http.patch('/api/todos/:id', async ({ params, request }) => {
+    const id = params.id as string
+    const idx = todos.findIndex((t) => t.id === id)
+    if (idx === -1) {
+      return HttpResponse.json(
+        { error: { code: 'not_found', message: 'todo not found' } },
+        { status: 404 },
+      )
+    }
+    const patch = (await request.json()) as Patch
+    const t = { ...todos[idx], ...patch, updatedAt: new Date().toISOString() }
+    if ('dueDate' in patch && patch.dueDate === null) t.dueDate = null
+    todos[idx] = t
+    return HttpResponse.json(t)
+  }),
+
+  http.delete('/api/todos/:id', ({ params }) => {
+    const id = params.id as string
+    const before = todos.length
+    todos = todos.filter((t) => t.id !== id)
+    if (todos.length === before) {
+      return HttpResponse.json(
+        { error: { code: 'not_found', message: 'todo not found' } },
+        { status: 404 },
+      )
+    }
+    return new HttpResponse(null, { status: 204 })
+  }),
+]
+```
+
+- [ ] **Step 4: MSW server 셋업**
+
+`tutorials-go/ai/superpowers/todo/frontend/src/__tests__/mocks/server.ts`:
+
+```ts
+import { setupServer } from 'msw/node'
+import { handlers } from './handlers'
+
+export const server = setupServer(...handlers)
+```
+
+- [ ] **Step 5: setup.ts에 MSW lifecycle 훅 등록**
+
+`tutorials-go/ai/superpowers/todo/frontend/src/__tests__/setup.ts` 전체 교체:
+
+```ts
+import { afterAll, afterEach, beforeAll } from 'vitest'
+import '@testing-library/react'
+import { server } from './mocks/server'
+import { resetMockTodos } from './mocks/handlers'
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => {
+  server.resetHandlers()
+  resetMockTodos([])
+})
+afterAll(() => server.close())
+```
+
+- [ ] **Step 6: 빌드 확인**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go/ai/superpowers/todo/frontend
+npm run build
+```
+
+Expected: 컴파일 성공.
+
+- [ ] **Step 7: 빈 테스트 실행 (MSW 셋업 자체가 깨지지 않는지)**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go/ai/superpowers/todo/frontend
+npm test -- --run
+```
+
+Expected: "No test files found" 또는 비슷한 메시지. 에러 없이 종료.
+
+- [ ] **Step 8: 커밋**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+git add ai/superpowers/todo/frontend/src/types.ts \
+        ai/superpowers/todo/frontend/src/api.ts \
+        ai/superpowers/todo/frontend/src/__tests__/mocks/handlers.ts \
+        ai/superpowers/todo/frontend/src/__tests__/mocks/server.ts \
+        ai/superpowers/todo/frontend/src/__tests__/setup.ts
+git commit -m "$(cat <<'EOF'
+[feat/todo-app] feat: types/api 클라이언트 + MSW 핸들러 (in-memory mock store)
+
+* types.ts는 BE 모델과 수기 동기화 (CLAUDE.md 정책)
+* api.ts: ApiError throw, 204 처리, query string 직렬화
+* MSW handlers는 BE 동작을 흉내내어 FE 통합 테스트의 contract 역할
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 6: useTodos hook
+
+### Task 6: `useTodos.ts` — useReducer + 비동기 액션
+
+**Files:**
+- Create: `tutorials-go/ai/superpowers/todo/frontend/src/hooks/useTodos.ts`
+- Create: `tutorials-go/ai/superpowers/todo/frontend/src/__tests__/useTodos.test.ts`
+
+- [ ] **Step 1: hook 테스트 작성**
+
+`tutorials-go/ai/superpowers/todo/frontend/src/__tests__/useTodos.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { useTodos } from '../hooks/useTodos'
+import { resetMockTodos } from './mocks/handlers'
+import type { Query } from '../types'
+
+const defaultQuery: Query = { status: 'all', sort: 'createdAt', order: 'desc' }
+
+describe('useTodos', () => {
+  it('초기 fetch 후 todos 채워짐', async () => {
+    resetMockTodos([
+      {
+        id: '1',
+        title: 'seeded',
+        completed: false,
+        priority: 'medium',
+        dueDate: null,
+        createdAt: '2026-04-01T00:00:00Z',
+        updatedAt: '2026-04-01T00:00:00Z',
+      },
+    ])
+    const { result } = renderHook(() => useTodos(defaultQuery))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.todos).toHaveLength(1)
+    expect(result.current.todos[0].title).toBe('seeded')
+  })
+
+  it('create 후 list refetch', async () => {
+    const { result } = renderHook(() => useTodos(defaultQuery))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.todos).toHaveLength(0)
+
+    await act(async () => {
+      await result.current.create({ title: '새 할일' })
+    })
+    await waitFor(() => expect(result.current.todos).toHaveLength(1))
+    expect(result.current.todos[0].title).toBe('새 할일')
+  })
+
+  it('update 후 list refetch', async () => {
+    const { result } = renderHook(() => useTodos(defaultQuery))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    await act(async () => {
+      await result.current.create({ title: 'x' })
+    })
+    await waitFor(() => expect(result.current.todos).toHaveLength(1))
+    const id = result.current.todos[0].id
+
+    await act(async () => {
+      await result.current.update(id, { completed: true })
+    })
+    await waitFor(() => expect(result.current.todos[0].completed).toBe(true))
+  })
+
+  it('remove 후 목록에서 제거', async () => {
+    const { result } = renderHook(() => useTodos(defaultQuery))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    await act(async () => {
+      await result.current.create({ title: 'x' })
+    })
+    await waitFor(() => expect(result.current.todos).toHaveLength(1))
+    const id = result.current.todos[0].id
+
+    await act(async () => {
+      await result.current.remove(id)
+    })
+    await waitFor(() => expect(result.current.todos).toHaveLength(0))
+  })
+
+  it('네트워크 실패 시 error 상태', async () => {
+    // BE down 시뮬: 핸들러 일시 비활성화
+    const { server } = await import('./mocks/server')
+    const { http, HttpResponse } = await import('msw')
+    server.use(http.get('/api/todos', () => HttpResponse.error()))
+
+    const { result } = renderHook(() => useTodos(defaultQuery))
+    await waitFor(() => expect(result.current.error).not.toBeNull())
+    expect(result.current.loading).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: 테스트 실행 (실패 예상)**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go/ai/superpowers/todo/frontend
+npm test -- --run
+```
+
+Expected: useTodos 미정의로 실패.
+
+- [ ] **Step 3: hook 구현**
+
+`tutorials-go/ai/superpowers/todo/frontend/src/hooks/useTodos.ts`:
+
+```ts
+import { useCallback, useEffect, useReducer, useRef } from 'react'
+import { api, ApiError } from '../api'
+import type { NewTodo, Patch, Query, Todo } from '../types'
+
+type State = {
+  todos: Todo[]
+  loading: boolean
+  error: string | null
+}
+
+type Action =
+  | { type: 'fetch_start' }
+  | { type: 'fetch_success'; todos: Todo[] }
+  | { type: 'fetch_error'; error: string }
+
+const initial: State = { todos: [], loading: false, error: null }
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'fetch_start':
+      return { ...state, loading: true, error: null }
+    case 'fetch_success':
+      return { todos: action.todos, loading: false, error: null }
+    case 'fetch_error':
+      return { ...state, loading: false, error: action.error }
+  }
+}
+
+export function useTodos(query: Query) {
+  const [state, dispatch] = useReducer(reducer, initial)
+  const queryRef = useRef(query)
+  queryRef.current = query
+
+  const refetch = useCallback(async () => {
+    dispatch({ type: 'fetch_start' })
+    try {
+      const todos = await api.list(queryRef.current)
+      dispatch({ type: 'fetch_success', todos })
+    } catch (e) {
+      const msg = e instanceof ApiError ? e.message : e instanceof Error ? e.message : '서버에 연결할 수 없습니다'
+      dispatch({ type: 'fetch_error', error: msg })
+    }
+  }, [])
+
+  useEffect(() => {
+    void refetch()
+  }, [query.status, query.sort, query.order, refetch])
+
+  const create = useCallback(
+    async (input: NewTodo) => {
+      await api.create(input)
+      await refetch()
+    },
+    [refetch],
+  )
+
+  const update = useCallback(
+    async (id: string, patch: Patch) => {
+      await api.update(id, patch)
+      await refetch()
+    },
+    [refetch],
+  )
+
+  const remove = useCallback(
+    async (id: string) => {
+      await api.remove(id)
+      await refetch()
+    },
+    [refetch],
+  )
+
+  return { ...state, create, update, remove, refetch }
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go/ai/superpowers/todo/frontend
+npm test -- --run
+```
+
+Expected: 5개 테스트 모두 통과.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+git add ai/superpowers/todo/frontend/src/hooks/useTodos.ts \
+        ai/superpowers/todo/frontend/src/__tests__/useTodos.test.ts
+git commit -m "$(cat <<'EOF'
+[feat/todo-app] feat: useTodos hook (useReducer + create/update/remove + 자동 refetch)
+
+* mutation 후 항상 list 재호출 (서버 사이드 정렬/필터 정합성 유지)
+* ApiError/Network 에러 모두 fetch_error로 누적
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 7: 컴포넌트
+
+### Task 7.1: `TodoForm.tsx`
+
+**Files:**
+- Create: `tutorials-go/ai/superpowers/todo/frontend/src/components/TodoForm.tsx`
+
+- [ ] **Step 1: 구현**
+
+```tsx
+import { useState, type FormEvent } from 'react'
+import type { NewTodo, Priority } from '../types'
+
+interface Props {
+  onCreate: (input: NewTodo) => Promise<void>
+}
+
+export function TodoForm({ onCreate }: Props) {
+  const [title, setTitle] = useState('')
+  const [priority, setPriority] = useState<Priority>('medium')
+  const [dueDate, setDueDate] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  const submit = async (e: FormEvent) => {
+    e.preventDefault()
+    if (!title.trim() || submitting) return
+    setSubmitting(true)
+    try {
+      await onCreate({
+        title: title.trim(),
+        priority,
+        dueDate: dueDate ? new Date(dueDate).toISOString() : undefined,
+      })
+      setTitle('')
+      setDueDate('')
+      setPriority('medium')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <form onSubmit={submit} aria-label="새 할일 추가">
+      <input
+        aria-label="제목"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="할 일 입력..."
+        maxLength={200}
+      />
+      <select
+        aria-label="우선순위"
+        value={priority}
+        onChange={(e) => setPriority(e.target.value as Priority)}
+      >
+        <option value="low">낮음</option>
+        <option value="medium">보통</option>
+        <option value="high">높음</option>
+      </select>
+      <input
+        aria-label="마감일"
+        type="datetime-local"
+        value={dueDate}
+        onChange={(e) => setDueDate(e.target.value)}
+      />
+      <button type="submit" disabled={!title.trim() || submitting}>추가</button>
+    </form>
+  )
+}
+```
+
+- [ ] **Step 2: 빌드 확인**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go/ai/superpowers/todo/frontend
+npm run build
+```
+
+Expected: 컴파일 성공.
+
+- [ ] **Step 3: 커밋**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+git add ai/superpowers/todo/frontend/src/components/TodoForm.tsx
+git commit -m "$(cat <<'EOF'
+[feat/todo-app] feat: TodoForm 컴포넌트 (title/priority/dueDate 입력)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7.2: `FilterBar.tsx`
+
+**Files:**
+- Create: `tutorials-go/ai/superpowers/todo/frontend/src/components/FilterBar.tsx`
+
+- [ ] **Step 1: 구현**
+
+```tsx
+import type { Order, Query, SortKey, Status } from '../types'
+
+interface Props {
+  query: Query
+  onChange: (next: Query) => void
+}
+
+export function FilterBar({ query, onChange }: Props) {
+  return (
+    <div role="toolbar" aria-label="필터/정렬">
+      <fieldset>
+        <legend>상태</legend>
+        {(['all', 'active', 'completed'] as Status[]).map((s) => (
+          <label key={s}>
+            <input
+              type="radio"
+              name="status"
+              value={s}
+              checked={query.status === s}
+              onChange={() => onChange({ ...query, status: s })}
+            />
+            {s === 'all' ? '전체' : s === 'active' ? '미완료' : '완료'}
+          </label>
+        ))}
+      </fieldset>
+      <label>
+        정렬
+        <select
+          value={query.sort}
+          onChange={(e) => onChange({ ...query, sort: e.target.value as SortKey })}
+        >
+          <option value="createdAt">생성일</option>
+          <option value="dueDate">마감일</option>
+          <option value="priority">우선순위</option>
+        </select>
+      </label>
+      <button
+        type="button"
+        aria-label="정렬 방향 토글"
+        onClick={() => onChange({ ...query, order: query.order === 'asc' ? 'desc' : 'asc' as Order })}
+      >
+        {query.order === 'asc' ? '↑' : '↓'}
+      </button>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: 빌드 확인**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go/ai/superpowers/todo/frontend
+npm run build
+```
+
+- [ ] **Step 3: 커밋**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+git add ai/superpowers/todo/frontend/src/components/FilterBar.tsx
+git commit -m "$(cat <<'EOF'
+[feat/todo-app] feat: FilterBar (status 라디오 / sort 셀렉트 / order 토글)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7.3: `TodoItem.tsx` + 컴포넌트 테스트
+
+**Files:**
+- Create: `tutorials-go/ai/superpowers/todo/frontend/src/components/TodoItem.tsx`
+- Create: `tutorials-go/ai/superpowers/todo/frontend/src/__tests__/TodoItem.test.tsx`
+
+- [ ] **Step 1: 컴포넌트 테스트 먼저**
+
+`tutorials-go/ai/superpowers/todo/frontend/src/__tests__/TodoItem.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { TodoItem } from '../components/TodoItem'
+import type { Todo } from '../types'
+
+function makeTodo(overrides: Partial<Todo> = {}): Todo {
+  return {
+    id: 'id1',
+    title: '할일 1',
+    completed: false,
+    priority: 'high',
+    dueDate: null,
+    createdAt: '2026-04-30T10:00:00Z',
+    updatedAt: '2026-04-30T10:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('TodoItem', () => {
+  it('priority 뱃지 표시', () => {
+    render(<TodoItem todo={makeTodo({ priority: 'high' })} onUpdate={vi.fn()} onRemove={vi.fn()} />)
+    expect(screen.getByText('높음')).toBeDefined()
+  })
+
+  it('dueDate 표시 (있을 때만)', () => {
+    const { rerender } = render(
+      <TodoItem todo={makeTodo({ dueDate: null })} onUpdate={vi.fn()} onRemove={vi.fn()} />,
+    )
+    expect(screen.queryByText(/마감/)).toBeNull()
+
+    rerender(
+      <TodoItem
+        todo={makeTodo({ dueDate: '2026-05-15T18:00:00Z' })}
+        onUpdate={vi.fn()}
+        onRemove={vi.fn()}
+      />,
+    )
+    expect(screen.getByText(/마감/)).toBeDefined()
+  })
+
+  it('체크박스 클릭 시 onUpdate 호출', async () => {
+    const onUpdate = vi.fn().mockResolvedValue(undefined)
+    render(<TodoItem todo={makeTodo()} onUpdate={onUpdate} onRemove={vi.fn()} />)
+    const cb = screen.getByRole('checkbox', { name: /완료/ })
+    await userEvent.click(cb)
+    expect(onUpdate).toHaveBeenCalledWith('id1', { completed: true })
+  })
+
+  it('삭제 버튼 클릭 시 onRemove 호출', async () => {
+    const onRemove = vi.fn().mockResolvedValue(undefined)
+    render(<TodoItem todo={makeTodo()} onUpdate={vi.fn()} onRemove={onRemove} />)
+    await userEvent.click(screen.getByRole('button', { name: /삭제/ }))
+    expect(onRemove).toHaveBeenCalledWith('id1')
+  })
+
+  it('제목 클릭 → 편집 → blur 시 onUpdate 호출', async () => {
+    const onUpdate = vi.fn().mockResolvedValue(undefined)
+    render(<TodoItem todo={makeTodo()} onUpdate={onUpdate} onRemove={vi.fn()} />)
+    const title = screen.getByText('할일 1')
+    await userEvent.click(title)
+    const input = screen.getByRole('textbox', { name: /제목/ })
+    await userEvent.clear(input)
+    await userEvent.type(input, '수정됨')
+    input.blur()
+    expect(onUpdate).toHaveBeenCalledWith('id1', { title: '수정됨' })
+  })
+})
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go/ai/superpowers/todo/frontend
+npm test -- --run
+```
+
+Expected: TodoItem 미정의 실패.
+
+- [ ] **Step 3: TodoItem 구현**
+
+`tutorials-go/ai/superpowers/todo/frontend/src/components/TodoItem.tsx`:
+
+```tsx
+import { useState, type KeyboardEvent } from 'react'
+import type { Patch, Priority, Todo } from '../types'
+
+interface Props {
+  todo: Todo
+  onUpdate: (id: string, patch: Patch) => Promise<void>
+  onRemove: (id: string) => Promise<void>
+}
+
+const priorityLabel: Record<Priority, string> = { low: '낮음', medium: '보통', high: '높음' }
+
+export function TodoItem({ todo, onUpdate, onRemove }: Props) {
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(todo.title)
+
+  const commit = () => {
+    setEditing(false)
+    const next = draft.trim()
+    if (next && next !== todo.title) {
+      void onUpdate(todo.id, { title: next })
+    } else {
+      setDraft(todo.title)
+    }
+  }
+
+  const onKey = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.currentTarget.blur()
+    } else if (e.key === 'Escape') {
+      setDraft(todo.title)
+      setEditing(false)
+    }
+  }
+
+  return (
+    <li>
+      <input
+        type="checkbox"
+        aria-label="완료"
+        checked={todo.completed}
+        onChange={(e) => onUpdate(todo.id, { completed: e.target.checked })}
+      />
+      {editing ? (
+        <input
+          aria-label="제목 편집"
+          value={draft}
+          autoFocus
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commit}
+          onKeyDown={onKey}
+        />
+      ) : (
+        <span onClick={() => setEditing(true)}>{todo.title}</span>
+      )}
+      <span data-priority={todo.priority}>{priorityLabel[todo.priority]}</span>
+      {todo.dueDate && <span>마감: {new Date(todo.dueDate).toLocaleString()}</span>}
+      <button type="button" aria-label="삭제" onClick={() => onRemove(todo.id)}>×</button>
+    </li>
+  )
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go/ai/superpowers/todo/frontend
+npm test -- --run
+```
+
+Expected: 5개 TodoItem 테스트 통과.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+git add ai/superpowers/todo/frontend/src/components/TodoItem.tsx \
+        ai/superpowers/todo/frontend/src/__tests__/TodoItem.test.tsx
+git commit -m "$(cat <<'EOF'
+[feat/todo-app] feat: TodoItem (체크박스/인라인 편집/삭제) + 컴포넌트 테스트
+
+* 제목 클릭→input 전환, blur/Enter로 저장, Escape로 취소
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7.4: `TodoList.tsx`
+
+**Files:**
+- Create: `tutorials-go/ai/superpowers/todo/frontend/src/components/TodoList.tsx`
+
+- [ ] **Step 1: 구현**
+
+```tsx
+import type { Patch, Todo } from '../types'
+import { TodoItem } from './TodoItem'
+
+interface Props {
+  todos: Todo[]
+  onUpdate: (id: string, patch: Patch) => Promise<void>
+  onRemove: (id: string) => Promise<void>
+}
+
+export function TodoList({ todos, onUpdate, onRemove }: Props) {
+  if (todos.length === 0) {
+    return <p>할 일이 없습니다.</p>
+  }
+  return (
+    <ul aria-label="할 일 목록">
+      {todos.map((t) => (
+        <TodoItem key={t.id} todo={t} onUpdate={onUpdate} onRemove={onRemove} />
+      ))}
+    </ul>
+  )
+}
+```
+
+- [ ] **Step 2: 빌드 확인**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go/ai/superpowers/todo/frontend
+npm run build
+```
+
+- [ ] **Step 3: 커밋**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+git add ai/superpowers/todo/frontend/src/components/TodoList.tsx
+git commit -m "$(cat <<'EOF'
+[feat/todo-app] feat: TodoList (빈 상태 처리 + TodoItem 매핑)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 8: App 통합
+
+### Task 8: `App.tsx` 조립 + `App.test.tsx` 통합 시나리오
+
+**Files:**
+- Modify: `tutorials-go/ai/superpowers/todo/frontend/src/App.tsx`
+- Create: `tutorials-go/ai/superpowers/todo/frontend/src/__tests__/App.test.tsx`
+
+- [ ] **Step 1: App 통합 테스트 먼저**
+
+`tutorials-go/ai/superpowers/todo/frontend/src/__tests__/App.test.tsx`:
+
+```tsx
+import { describe, it, expect } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import App from '../App'
+import { server } from './mocks/server'
+import { http, HttpResponse } from 'msw'
+
+describe('App 통합 시나리오', () => {
+  it('빈 상태 → 추가 → 토글 → 삭제', async () => {
+    render(<App />)
+    await waitFor(() => expect(screen.getByText('할 일이 없습니다.')).toBeDefined())
+
+    // 추가
+    await userEvent.type(screen.getByRole('textbox', { name: '제목' }), '우유 사기')
+    await userEvent.click(screen.getByRole('button', { name: '추가' }))
+    await waitFor(() => expect(screen.getByText('우유 사기')).toBeDefined())
+
+    // 완료 토글
+    await userEvent.click(screen.getByRole('checkbox', { name: /완료/ }))
+    await waitFor(() => {
+      const cb = screen.getByRole('checkbox', { name: /완료/ }) as HTMLInputElement
+      expect(cb.checked).toBe(true)
+    })
+
+    // 삭제
+    await userEvent.click(screen.getByRole('button', { name: '삭제' }))
+    await waitFor(() => expect(screen.getByText('할 일이 없습니다.')).toBeDefined())
+  })
+
+  it('네트워크 실패 시 에러 배너 표시', async () => {
+    server.use(http.get('/api/todos', () => HttpResponse.error()))
+    render(<App />)
+    await waitFor(() => expect(screen.getByRole('alert')).toBeDefined())
+  })
+})
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go/ai/superpowers/todo/frontend
+npm test -- --run App
+```
+
+Expected: App이 아직 placeholder라 통합 시나리오 실패.
+
+- [ ] **Step 3: App.tsx 통합 구현**
+
+`tutorials-go/ai/superpowers/todo/frontend/src/App.tsx`:
+
+```tsx
+import { useState } from 'react'
+import { useTodos } from './hooks/useTodos'
+import { TodoForm } from './components/TodoForm'
+import { FilterBar } from './components/FilterBar'
+import { TodoList } from './components/TodoList'
+import type { Query } from './types'
+
+const defaultQuery: Query = { status: 'all', sort: 'createdAt', order: 'desc' }
+
+export default function App() {
+  const [query, setQuery] = useState<Query>(defaultQuery)
+  const { todos, error, create, update, remove } = useTodos(query)
+
+  return (
+    <main>
+      <h1>Superpowers Todo</h1>
+      {error && <div role="alert">에러: {error}</div>}
+      <TodoForm onCreate={create} />
+      <FilterBar query={query} onChange={setQuery} />
+      <TodoList todos={todos} onUpdate={update} onRemove={remove} />
+    </main>
+  )
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인 (전체)**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go/ai/superpowers/todo/frontend
+npm test -- --run
+```
+
+Expected: useTodos, TodoItem, App 테스트 모두 통과.
+
+- [ ] **Step 5: 빌드 확인**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go/ai/superpowers/todo/frontend
+npm run build
+```
+
+Expected: 컴파일 성공.
+
+- [ ] **Step 6: 커밋**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+git add ai/superpowers/todo/frontend/src/App.tsx \
+        ai/superpowers/todo/frontend/src/__tests__/App.test.tsx
+git commit -m "$(cat <<'EOF'
+[feat/todo-app] feat: App 조립 + 통합 시나리오 테스트 (MSW 풀 라운드트립)
+
+* 빈 상태 → 추가 → 완료 토글 → 삭제 사이클
+* /api/todos GET 실패 시 alert role 배너 노출
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 9: 통합 검증
+
+### Task 9.1: README 마무리 + 수동 e2e
+
+**Files:**
+- Modify: `tutorials-go/ai/superpowers/todo/README.md`
+
+- [ ] **Step 1: README에 동작 검증 절차 추가**
+
+기존 README의 "## 정책" 섹션 위에 다음을 삽입:
+
+```markdown
+## 동작 검증
+
+### Backend 단독 검증
+
+```bash
+make dev-be
+# 다른 터미널에서:
+curl -s http://localhost:8080/api/health
+curl -s -X POST -H "Content-Type: application/json" \
+  -d '{"title":"우유 사기","priority":"high"}' \
+  http://localhost:8080/api/todos | tee /tmp/created.json
+ID=$(cat /tmp/created.json | python3 -c "import sys,json;print(json.load(sys.stdin)['id'])")
+curl -s -X PATCH -H "Content-Type: application/json" \
+  -d '{"completed":true}' http://localhost:8080/api/todos/$ID
+curl -s http://localhost:8080/api/todos
+curl -s -X DELETE -i http://localhost:8080/api/todos/$ID | head -1
+```
+
+### Frontend + Backend 통합 검증
+
+1. 터미널 1: `make dev-be`
+2. 터미널 2: `make dev-fe`
+3. 브라우저로 http://localhost:5173 접속
+4. 시나리오:
+   - 입력 → 추가 → 목록에 등장
+   - 체크박스 토글 → 완료 상태 변화
+   - FilterBar로 필터링/정렬 변경 → 즉시 반영
+   - 제목 클릭 → 편집 → blur로 저장
+   - 삭제 버튼 → 항목 제거
+5. 백엔드 종료 후 새로고침 → "에러" 배너 표시 확인
+```
+
+- [ ] **Step 2: 전체 테스트 실행 (회귀 점검)**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go/ai/superpowers/todo
+make test
+```
+
+Expected: 백엔드 + 프론트엔드 테스트 모두 통과.
+
+- [ ] **Step 3: 수동 e2e (사람이 직접)**
+
+위 README "Frontend + Backend 통합 검증" 시나리오를 그대로 수행하고 결과 확인. 모두 정상 동작 시 다음 단계.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+git add ai/superpowers/todo/README.md
+git commit -m "$(cat <<'EOF'
+[feat/todo-app] docs: 동작 검증 절차 (curl + 수동 e2e) README 추가
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 10: Code Review
+
+### Task 10: superpowers code-review skill 호출
+
+**Files:**
+- 변경 없음 (리뷰 후 발견 시 수정)
+
+- [ ] **Step 1: `superpowers:requesting-code-review` skill 호출**
+
+리뷰 대상: `feat/todo-app` 브랜치의 모든 커밋. 리뷰어에게 다음을 명시적으로 요청:
+
+- 도메인 모델 검증 누락 케이스가 있는가?
+- Store 동시성에 미묘한 race가 있는가? (예: Update 중 Get이 부분 갱신본을 보지 않는가?)
+- handler의 PATCH null 처리가 모든 필드에서 일관되게 동작하는가?
+- 프론트엔드의 mutation→refetch 패턴이 race 가능성이 있는가? (예: 빠르게 두 번 클릭)
+- 에러 메시지가 사용자에게 충분히 명확한가?
+- Go/TypeScript 코드 스타일이 프로젝트 컨벤션 (`tutorials-go/.claude/rules/*.md`)을 따르는가?
+
+- [ ] **Step 2: 리뷰 코멘트 정리 후 수정 (있을 시)**
+
+각 critical/major 코멘트에 대해 별도 fixup 커밋 생성.
+
+- [ ] **Step 3: 최종 검증**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go/ai/superpowers/todo
+make test
+```
+
+Expected: 모든 테스트 통과.
+
+- [ ] **Step 4: PR 생성 (사용자 컨펌 후)**
+
+```bash
+cd /Users/user/src/workspace_blog3/tutorials-go
+git push -u origin feat/todo-app
+gh pr create --title "feat: superpowers todo app (학습 샘플)" --body "$(cat <<'EOF'
+## Summary
+- Echo + React + in-memory Todo 웹 애플리케이션 (학습용)
+- superpowers plugin skill 사이클(brainstorm → plan → TDD → review)을 풀로 체험
+- BE/FE 두 프로세스 분리, Vite proxy로 dev 통합
+
+## Test plan
+- [ ] `make test-be` 통과 (race 포함)
+- [ ] `make test-fe` 통과
+- [ ] BE 단독 curl CRUD 사이클 동작
+- [ ] BE+FE 통합 브라우저에서 CRUD 1 사이클 동작
+- [ ] BE 종료 시 FE 에러 배너 표시
+
+## 문서
+- 설계: `ai/superpowers/todo/docs/superpowers/specs/2026-04-30-todo-app-design.md`
+- 구현 plan: `ai/superpowers/todo/docs/superpowers/plans/2026-04-30-todo-app-plan.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)" --assignee kenshin579
+```
+
+---
+
+## 완료 정의
+
+- [ ] Pre-flight Task A 완료 (브랜치 + spec/plan 커밋)
+- [ ] Phase 0 완료 (스캐폴드 빌드 가능)
+- [ ] Phase 1~3 완료 (`go test -race ./ai/superpowers/todo/backend/todo/...` 통과)
+- [ ] Phase 4 완료 (httptest 통합 테스트 통과 + curl 헬스체크 OK)
+- [ ] Phase 5~8 완료 (`npm test -- --run` 통과 + `npm run build` 성공)
+- [ ] Phase 9 완료 (사람이 브라우저에서 CRUD 1 사이클 직접 수행)
+- [ ] Phase 10 완료 (code-review 코멘트 0건 critical, PR 생성)
+
+각 Phase 종료 시 `make test-be` (백엔드) 또는 `make test-fe` (프론트엔드) 또는 `make test` (둘 다)로 회귀 점검 후 다음 Phase 진입.

--- a/ai/superpowers/todo/docs/superpowers/specs/2026-04-30-todo-app-design.md
+++ b/ai/superpowers/todo/docs/superpowers/specs/2026-04-30-todo-app-design.md
@@ -1,0 +1,650 @@
+# Todo Web Application — 설계 문서
+
+- **작성일**: 2026-04-30
+- **위치**: `tutorials-go/ai/superpowers/todo/`
+- **목적**: superpowers skill 사이클(brainstorm → plan → TDD → review)을 풀로 체험하기 위한 학습용 샘플 애플리케이션
+- **Stack**: Go 1.26 (Echo), React 19 (Vite, TypeScript), in-memory persistence
+- **상태**: 설계 확정 (구현 미착수)
+
+---
+
+## 1. 목적과 범위
+
+### 1.1 목적
+
+Todo 웹 애플리케이션을 처음부터 끝까지 만들면서, superpowers 플러그인의 다양한 skill을 자연스럽게 트리거하고 사용법을 익힌다. 부수적으로 다음을 학습한다.
+
+- Go Echo + React/TypeScript 분리 아키텍처
+- in-memory store의 동시성 안전 설계
+- 서버 사이드 필터/정렬을 위한 query 파라미터 처리
+- TDD 사이클 (Red → Green → Refactor) 의 실전 적용
+- PATCH 엔드포인트에서 "필드 부재" vs "null 명시"를 구분하는 Go 패턴
+
+### 1.2 기능 범위
+
+**포함**
+
+- Todo CRUD (생성/조회/수정/삭제/완료 토글)
+- 상태 필터 (전체 / 미완료 / 완료)
+- 우선순위 (low / medium / high)
+- 마감일 (옵셔널, RFC3339)
+- 정렬 (생성일 / 마감일 / 우선순위) × (asc / desc)
+- 인라인 제목 편집
+
+**의도적 제외 (YAGNI)**
+
+- 사용자 인증/계정 — 학습 목적에 노이즈
+- 영구 저장 (DB) — in-memory 컨셉
+- 카테고리/태그 — 도메인 비대화
+- 일괄 조작, 검색, 페이지네이션 — 복잡도 ↑
+- 단일 항목 조회 (`GET /api/todos/{id}`) — UI 흐름에 불필요
+- 낙관적 업데이트 — 학습 단순성 유지
+- OpenAPI/타입 codegen — types.ts 수기 동기화로 충분
+
+### 1.3 성공 기준
+
+- 모든 Phase가 superpowers `executing-plans` skill로 체크포인트 통과
+- `cd backend && go test -race ./... && go vet ./...` 무경고
+- `cd frontend && npm test && npm run build` 무경고
+- 사용자가 BE+FE 동시 실행 후 브라우저에서 CRUD 1 사이클을 끝낼 수 있음
+- `superpowers:requesting-code-review` 결과 critical 이슈 0개
+
+---
+
+## 2. 시스템 아키텍처
+
+### 2.1 프로세스 구조
+
+두 프로세스 분리 운영. 단일 binary embed 방식은 채택하지 않는다.
+
+```mermaid
+flowchart LR
+    User((User Browser))
+    User -->|http://localhost:5173| FE[Vite Dev Server]
+    FE -->|/api/* proxy| BE[Echo Server :8080]
+    BE -->|in-memory| Store[(map + sync.RWMutex)]
+```
+
+| 모드 | 명령 | 포트 |
+|---|---|---|
+| Dev BE | `make dev-be` (`cd backend && go run .`) | 8080 |
+| Dev FE | `make dev-fe` (`cd frontend && npm run dev`) | 5173 |
+| Prod-like FE | `make preview-fe` (`vite preview`) | 4173 |
+
+CORS는 `echo/middleware/cors` 가 `http://localhost:5173`, `http://localhost:4173` 을 허용한다 (Vite proxy 미사용 시나리오 대비).
+
+### 2.2 디렉토리 레이아웃
+
+```
+tutorials-go/ai/superpowers/todo/
+├── README.md
+├── Makefile                        # dev-be / dev-fe / build / test / preview-fe
+├── backend/
+│   ├── main.go                     # 진입점 (server.New + Start)
+│   ├── server/
+│   │   ├── server.go               # Echo 인스턴스, 라우팅, 미들웨어(logger/recover/cors)
+│   │   └── server_test.go          # 통합 (httptest.NewServer)
+│   └── todo/                       # package todo (도메인)
+│       ├── todo.go                 # Priority, Todo, NewTodo, Patch, Validate, ValidationError, ErrNotFound
+│       ├── todo_test.go            # 검증 TDD
+│       ├── store.go                # InMemoryStore (sync.RWMutex)
+│       ├── store_test.go           # CRUD + 동시성 + 필터/정렬 TDD
+│       ├── handler.go              # Echo 핸들러
+│       └── handler_test.go         # 핸들러 TDD (httptest)
+├── frontend/
+│   ├── package.json
+│   ├── vite.config.ts              # /api/* → http://localhost:8080 proxy
+│   ├── tsconfig.json
+│   ├── index.html
+│   └── src/
+│       ├── main.tsx
+│       ├── App.tsx
+│       ├── api.ts                  # 타입 안전 fetch wrapper
+│       ├── types.ts                # Todo, NewTodo, Patch, Priority, Query
+│       ├── components/
+│       │   ├── TodoList.tsx
+│       │   ├── TodoItem.tsx
+│       │   ├── TodoForm.tsx
+│       │   └── FilterBar.tsx
+│       ├── hooks/
+│       │   └── useTodos.ts         # useReducer + API 호출 캡슐화
+│       ├── index.css               # 단일 CSS 파일
+│       └── __tests__/
+│           ├── App.test.tsx        # MSW로 API mock + 통합 시나리오
+│           └── TodoItem.test.tsx
+└── docs/superpowers/
+    ├── specs/2026-04-30-todo-app-design.md   # 본 문서
+    └── plans/2026-04-30-todo-app-plan.md     # writing-plans 산출물 (다음 단계)
+```
+
+**Go 모듈**: `tutorials-go` 루트 `go.mod`(`go 1.26.0`)를 그대로 사용. import path는 `github.com/kenshin579/tutorials-go/ai/superpowers/todo/backend/{server,todo}`.
+
+### 2.3 백엔드 레이어 분리
+
+```mermaid
+flowchart TD
+    H["server.Echo Routes"] --> TH["todo.Handler<br/>(HTTP I/O 전담)"]
+    TH --> TS["todo.Store<br/>(도메인 로직)"]
+    TS --> M[("map[string]Todo<br/>+ sync.RWMutex")]
+```
+
+- **`server`**: Echo 인스턴스 구성, 미들웨어, 라우트 등록만. 도메인 무지.
+- **`todo.Handler`**: HTTP I/O. 요청 파싱/검증, 응답 직렬화, 도메인 에러→HTTP 상태 매핑.
+- **`todo.Store`**: 도메인 핵심. HTTP/JSON 모름. Go 타입만 받고 반환.
+
+이 분리가 곧 TDD 단위가 된다.
+
+---
+
+## 3. 도메인 모델
+
+### 3.1 Todo
+
+```go
+type Priority string
+
+const (
+    PriorityLow    Priority = "low"
+    PriorityMedium Priority = "medium"
+    PriorityHigh   Priority = "high"
+)
+
+type Todo struct {
+    ID        string     `json:"id"`         // UUID v4 (서버 생성)
+    Title     string     `json:"title"`      // 1-200자, trim 후 검증
+    Completed bool       `json:"completed"`  // 기본 false
+    Priority  Priority   `json:"priority"`   // 기본 medium
+    DueDate   *time.Time `json:"dueDate"`    // 옵셔널, RFC3339 (UTC)
+    CreatedAt time.Time  `json:"createdAt"`
+    UpdatedAt time.Time  `json:"updatedAt"`
+}
+```
+
+### 3.2 검증 규칙
+
+| 필드 | 규칙 |
+|---|---|
+| `Title` | `strings.TrimSpace` 후 길이 1~200자. 빈 문자열 금지. |
+| `Priority` | `low` / `medium` / `high` 중 하나. 부재 시 `medium` 기본값. |
+| `DueDate` | 옵셔널. 있으면 RFC3339 파싱 가능해야 함. 과거 날짜 허용. |
+| `ID` | 클라이언트 입력 무시. 서버가 `uuid.NewString()` 생성. |
+| `CreatedAt`, `UpdatedAt` | 서버 설정. 클라이언트 입력 무시. |
+
+### 3.3 입력/패치 모델
+
+```go
+type NewTodo struct {
+    Title    string
+    Priority Priority   // 빈 값이면 medium
+    DueDate  *time.Time // nil 허용
+}
+
+type Patch struct {
+    Title        *string    // nil이면 미변경
+    Completed    *bool
+    Priority     *Priority
+    DueDate      *time.Time // 새 값 (Set + non-null)
+    ClearDueDate bool       // true면 nil로 클리어 (JSON null 명시)
+}
+```
+
+`Patch.DueDate`와 `Patch.ClearDueDate` 구분이 PATCH의 핵심. handler가 `map[string]json.RawMessage` 1차 디코딩으로 키 존재 여부를 판별한 후 채운다 (3.5 참조).
+
+### 3.4 에러 타입
+
+```go
+var ErrNotFound = errors.New("todo not found")
+
+type ValidationError struct {
+    Field   string
+    Message string
+}
+
+func (e *ValidationError) Error() string { return e.Message }
+```
+
+handler는 `errors.Is(err, ErrNotFound)` 와 `errors.As(err, &verr)` 로 분기.
+
+### 3.5 PATCH 의미론
+
+| 요청 본문 | 해석 | 결과 |
+|---|---|---|
+| `{}` | 변경 없음 | 400 `validation_failed` |
+| `{"completed": true}` | completed만 변경 | 200 |
+| `{"dueDate": null}` | 마감일 클리어 (`ClearDueDate=true`) | 200 |
+| `{"dueDate": "2026-05-15T18:00:00Z"}` | 마감일 설정 | 200 |
+| `{"priority": "urgent"}` | 잘못된 값 | 400 `validation_failed` |
+| `{"title": null}`, `{"completed": null}`, `{"priority": null}` | null 허용되지 않는 필드 | 400 `validation_failed`, field=해당 키 |
+
+**Null 정책**: `dueDate` 만 명시적 null을 받아들여 클리어. 그 외 모든 필드에서 null은 검증 에러. handler는 `json.RawMessage` 바이트가 `null` 인지 먼저 체크하고, 해당 필드가 nullable이 아니면 `*ValidationError` 반환.
+
+**구현 패턴 (handler 안)**:
+
+```go
+var raw map[string]json.RawMessage
+if err := c.Bind(&raw); err != nil { /* 400 invalid_json */ }
+
+patch := Patch{}
+if v, ok := raw["dueDate"]; ok {
+    if string(bytes.TrimSpace(v)) == "null" {
+        patch.ClearDueDate = true
+    } else {
+        var t time.Time
+        if err := json.Unmarshal(v, &t); err != nil { /* 400 */ }
+        patch.DueDate = &t
+    }
+}
+// title, completed, priority도 같은 방식으로 키 존재 → unmarshal
+```
+
+이 패턴은 표준 Go idiom이며 table-driven 테스트로 풍부하게 검증 가능.
+
+---
+
+## 4. REST API
+
+### 4.1 엔드포인트
+
+| Method | Path | 설명 | 성공 응답 |
+|---|---|---|---|
+| `GET` | `/api/todos` | 목록 (필터/정렬) | 200 `[]Todo` |
+| `POST` | `/api/todos` | 생성 | 201 `Todo` |
+| `PATCH` | `/api/todos/{id}` | 부분 수정 | 200 `Todo` |
+| `DELETE` | `/api/todos/{id}` | 삭제 | 204 (no body) |
+| `GET` | `/api/health` | 헬스체크 | 200 `{"status":"ok"}` |
+
+### 4.2 `GET /api/todos` 쿼리 파라미터
+
+| Param | 값 | 기본값 |
+|---|---|---|
+| `status` | `all` / `active` / `completed` | `all` |
+| `sort` | `createdAt` / `dueDate` / `priority` | `createdAt` |
+| `order` | `asc` / `desc` | `desc` |
+
+### 4.3 정렬 규칙
+
+- `priority` 정렬: `low=1`, `medium=2`, `high=3`. asc는 low → high.
+- `dueDate` 정렬: `nil`은 order 무관 **항상 마지막** (결정적 동작).
+- 안정 정렬 (`sort.SliceStable`). 동일 키일 때 `createdAt asc`로 tie-break.
+
+### 4.4 요청 본문 예시
+
+```jsonc
+// POST /api/todos
+{ "title": "장보기", "priority": "high", "dueDate": "2026-05-15T18:00:00Z" }
+
+// PATCH /api/todos/{id}
+{ "completed": true }
+```
+
+### 4.5 에러 응답 (전 엔드포인트 통일)
+
+```json
+{
+  "error": {
+    "code": "validation_failed",
+    "message": "title is required",
+    "details": { "field": "title" }
+  }
+}
+```
+
+| HTTP | code | 상황 |
+|---|---|---|
+| 400 | `validation_failed` | 본문/쿼리 검증 실패 |
+| 400 | `invalid_json` | JSON 파싱 실패 |
+| 404 | `not_found` | 해당 id의 todo 없음 |
+| 405 | `method_not_allowed` | Echo 자동 처리 |
+| 500 | `internal_error` | 예기치 못한 에러 (메시지 마스킹) |
+
+---
+
+## 5. Store 동시성 설계
+
+### 5.1 자료 구조
+
+```go
+type Store struct {
+    mu    sync.RWMutex
+    todos map[string]Todo // 값 타입 (포인터 X)
+}
+```
+
+값 타입 사용 이유: `Get`/`List`가 값 복사로 반환되어 호출자가 mutate해도 store에 영향 없음. (포인터였다면 외부에서 store 내부를 변경할 수 있음.)
+
+### 5.2 메서드 시그니처
+
+```go
+func (s *Store) Add(input NewTodo) Todo                       // 쓰기락
+func (s *Store) Get(id string) (Todo, bool)                   // 읽기락
+func (s *Store) Update(id string, p Patch) (Todo, error)      // 쓰기락 — ErrNotFound 가능
+func (s *Store) Delete(id string) error                       // 쓰기락 — ErrNotFound 가능
+func (s *Store) List(q Query) []Todo                          // 읽기락 + sort
+```
+
+- `Add`/`Update`는 ID/timestamp를 store가 채운다. 클라이언트 입력 ID는 무시.
+- `List`는 락 안에서 슬라이스 build → 락 해제 → sort. 락 점유 시간 최소화.
+
+### 5.3 동시성 보장
+
+- 모든 mutation은 `mu.Lock()`, 모든 read는 `mu.RLock()`.
+- 동시성 검증을 위한 전용 테스트:
+
+```go
+func TestStore_ConcurrentAddList(t *testing.T) {
+    t.Parallel()
+    s := NewStore()
+    var wg sync.WaitGroup
+    for i := 0; i < 100; i++ {
+        wg.Add(1)
+        go func(i int) {
+            defer wg.Done()
+            s.Add(NewTodo{Title: fmt.Sprintf("t-%d", i)})
+        }(i)
+    }
+    // 동시에 List 반복 호출
+    done := make(chan struct{})
+    go func() {
+        for {
+            select {
+            case <-done:
+                return
+            default:
+                _ = s.List(Query{})
+            }
+        }
+    }()
+    wg.Wait()
+    close(done)
+    assert.Len(t, s.List(Query{}), 100)
+}
+```
+
+Makefile의 test 타겟은 항상 `-race` 플래그를 켠다.
+
+### 5.4 동시 mutation 정책
+
+- 같은 id에 대한 동시 PATCH: **last-write-wins** (버전 필드 미도입). 학습 샘플 단순성 우선.
+- 탭1이 DELETE 후 탭2가 PATCH: 탭2는 404 받음. 프론트엔드는 에러 배너 표시 + 자동 refetch로 화면 동기화.
+
+---
+
+## 6. 프론트엔드 설계
+
+### 6.1 컴포넌트 트리
+
+```
+App
+├── FilterBar            (status / sort / order 변경 → query 갱신)
+├── TodoForm             (title, priority, dueDate → onCreate)
+└── TodoList
+    └── TodoItem[]       (체크박스 / 인라인 제목 편집 / 삭제)
+```
+
+- App = 상태 owner. `useTodos(query)` 호출, query는 자체 useState.
+- 자식은 모두 presentational. props로 데이터 + callback. 자체 fetch 없음.
+
+### 6.2 `useTodos` hook
+
+```ts
+type State = { todos: Todo[]; loading: boolean; error: string | null }
+
+type Action =
+  | { type: 'fetch_start' }
+  | { type: 'fetch_success'; todos: Todo[] }
+  | { type: 'fetch_error'; error: string }
+
+function useTodos(query: Query) {
+  const [state, dispatch] = useReducer(reducer, { todos: [], loading: false, error: null })
+
+  useEffect(() => {
+    dispatch({ type: 'fetch_start' })
+    api.list(query)
+      .then((todos) => dispatch({ type: 'fetch_success', todos }))
+      .catch((err) => dispatch({ type: 'fetch_error', error: err.message }))
+  }, [query.status, query.sort, query.order])
+
+  const refetch = () => { /* 동일 로직 */ }
+
+  return {
+    ...state,
+    create: async (input) => { await api.create(input); refetch() },
+    update: async (id, patch) => { await api.update(id, patch); refetch() },
+    remove: async (id) => { await api.remove(id); refetch() },
+    refetch,
+  }
+}
+```
+
+**핵심 결정**: 모든 mutation 후 list 재호출. 서버 사이드 정렬/필터이기 때문에 mutation 결과가 현재 뷰에 머물지 빠질지 서버 의견이 정답이다. 클라이언트 추측은 일관성을 깬다. in-memory store라 latency 무시 가능.
+
+### 6.3 API 클라이언트 (`api.ts`)
+
+```ts
+const BASE = '/api'
+
+async function call<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(BASE + path, {
+    ...init,
+    headers: { 'Content-Type': 'application/json', ...(init?.headers ?? {}) },
+  })
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}))
+    throw new ApiError(body.error?.code ?? 'unknown', body.error?.message ?? res.statusText)
+  }
+  return res.status === 204 ? (undefined as T) : res.json()
+}
+
+export class ApiError extends Error {
+  constructor(public code: string, message: string) { super(message) }
+}
+
+export const api = {
+  list:   (q: Query)                  => call<Todo[]>(`/todos?${new URLSearchParams(q as any)}`),
+  create: (input: NewTodo)            => call<Todo>('/todos', { method: 'POST',   body: JSON.stringify(input) }),
+  update: (id: string, patch: Patch)  => call<Todo>(`/todos/${id}`, { method: 'PATCH', body: JSON.stringify(patch) }),
+  remove: (id: string)                => call<void>(`/todos/${id}`, { method: 'DELETE' }),
+}
+```
+
+### 6.4 타입 동기화 정책
+
+`types.ts`의 `Todo`/`NewTodo`/`Patch`/`Priority`/`Query` 는 백엔드 JSON 모델과 **수기 동기화**. README에 "BE 모델 변경 시 types.ts도 함께 수정" 주의문 명시. OpenAPI/codegen은 학습 노이즈로 도입하지 않는다.
+
+### 6.5 UI 명세
+
+| 컴포넌트 | 표시 요소 | 인터랙션 |
+|---|---|---|
+| `TodoForm` | title input, priority select, dueDate input(`datetime-local`, optional) | Enter 또는 Add 버튼 → onCreate, 성공 시 입력 클리어 |
+| `FilterBar` | status 라디오(All/Active/Completed), sort 셀렉트, order 토글 (↑/↓) | 변경 즉시 query 갱신 → useEffect로 자동 refetch |
+| `TodoItem` | 체크박스, 제목(클릭→편집), priority 뱃지(색상), dueDate 표시(있을 때), 삭제 버튼 | 체크 → onUpdate({completed}), 제목 blur/Enter → onUpdate({title}), 삭제 → onRemove |
+| 에러 배너 | `state.error` 있을 때 상단 표시 | 닫기 버튼 |
+
+### 6.6 타임존 처리
+
+- 서버: 항상 UTC RFC3339로 저장/반환.
+- 프론트: `datetime-local` 입력은 로컬 시간 → ISO 변환 후 전송. 표시는 `toLocaleString()`로 사용자 로케일 맞춤.
+
+### 6.7 스타일링
+
+순수 CSS 단일 파일 (`src/index.css`). Tailwind/CSS-in-JS 미도입.
+
+---
+
+## 7. 에러 처리 책임 분배
+
+| 레이어 | 책임 |
+|---|---|
+| **Store** | 도메인 에러만 반환 (`ErrNotFound`, `*ValidationError`). HTTP 무지. panic 없음. |
+| **Handler** | JSON 파싱 에러 → `400 invalid_json` / 도메인 에러 → `writeError` 헬퍼로 매핑 |
+| **Echo middleware** | `Logger()` 모든 요청, `Recover()` panic 캡처 (500), `CORS` 프리플라이트 |
+| **Frontend `api.ts`** | non-2xx → `ApiError(code, message)` throw / 네트워크 실패 → 일반 `Error` 통과 |
+| **Frontend reducer** | `fetch_error` 액션 → 상태에 누적, UI 배너로 표시 |
+
+`writeError` 헬퍼 (handler에서 한 곳만):
+
+```go
+// errBody는 4.5의 JSON 형태를 만든다.
+func errBody(code, msg string, details map[string]any) echo.Map {
+    body := echo.Map{"code": code, "message": msg}
+    if details != nil {
+        body["details"] = details
+    }
+    return echo.Map{"error": body}
+}
+
+func writeError(c echo.Context, err error) error {
+    var verr *ValidationError
+    switch {
+    case errors.As(err, &verr):
+        return c.JSON(400, errBody("validation_failed", verr.Message, map[string]any{"field": verr.Field}))
+    case errors.Is(err, ErrNotFound):
+        return c.JSON(404, errBody("not_found", err.Error(), nil))
+    default:
+        c.Logger().Error(err)
+        return c.JSON(500, errBody("internal_error", "internal server error", nil))
+    }
+}
+```
+
+---
+
+## 8. 엣지 케이스
+
+| # | 시나리오 | 동작 | 검증 위치 |
+|---|---|---|---|
+| 1 | `title: "  "` (공백만) | trim 후 빈 문자열 → 400 validation_failed, field=title | store_test, handler_test |
+| 2 | title 길이 201 | 400 validation_failed | handler_test (table) |
+| 3 | `priority: "urgent"` | 400 validation_failed | handler_test |
+| 4 | `dueDate: "2026-13-01"` | 400 validation_failed (RFC3339 parse 실패) | handler_test |
+| 5 | dueDate 과거 | 허용 | todo_test |
+| 6 | `PATCH {}` 빈 객체 | 400 validation_failed | handler_test |
+| 7 | `PATCH {"dueDate": null}` | 마감일 클리어, 200 | handler_test |
+| 8 | DELETE 없는 id | 404 not_found | handler_test |
+| 9 | 동시 PATCH 같은 id | last-write-wins (README에 정책 명시) | (테스트 제외) |
+| 10 | 탭1 DELETE, 탭2 PATCH | 탭2 = 404 → 배너 + 자동 refetch | App.test.tsx |
+| 11 | 서버 재시작 | 데이터 전부 손실, refetch가 빈 목록 | README 명시 |
+| 12 | DueDate 타임존 | 서버 UTC, FE는 datetime-local→ISO 변환 | helper |
+| 13 | `?sort=invalid` | 400 validation_failed | handler_test |
+| 14 | priority 정렬 + 동일 우선순위 | createdAt asc로 tie-break | store_test |
+| 15 | dueDate 정렬 + nil 섞임 | nil 항상 마지막 | store_test |
+| 16 | 네트워크 실패 (BE down) | api.ts throw → 배너 "서버에 연결할 수 없습니다" | App.test.tsx (MSW 시뮬) |
+
+---
+
+## 9. 테스트 전략
+
+### 9.1 테스트 피라미드
+
+- BE unit (todo 패키지): ~80% — 도메인 검증, store, handler
+- BE integration (server 패키지): ~15% — httptest.NewServer로 풀 라우팅
+- FE smoke (App + TodoItem): ~5%
+
+### 9.2 백엔드 컨벤션
+
+- **Table-driven** 우선 (검증, query 파싱, patch 의미론)
+- **`t.Parallel()`** 모든 subtest
+- **`go test -race ./...`** 가 Makefile 기본
+- **Fresh store per test** (`newTestStore()` 헬퍼)
+- **testify/assert** 채택 (`tutorials-go` 프로젝트 컨벤션 — `.claude/rules/testing.md`)
+- **테스트 함수명 형식**: `TestXxx_설명` (예: `TestStore_ConcurrentAddList`, `TestHandler_Create_Returns400OnEmptyTitle`)
+- **httptest.NewServer + 실제 라우터**로 server_test 1개
+
+### 9.3 프론트엔드 컨벤션
+
+- **MSW** (Mock Service Worker)로 fetch 가로채기
+- **`render` + `userEvent`** (`fireEvent` 대신)
+- **`findBy*`** (await) 비동기 렌더 대기
+
+### 9.4 코드 스타일 (`.claude/rules/code-style.md` 준수)
+
+- `gofmt` / `goimports` 적용 필수
+- 에러는 즉시 처리 (`if err != nil { return err }` 패턴)
+- 패키지 export 함수/타입에 GoDoc 주석 작성 (예: `Store`, `NewStore`, `Add`, `Validate`, `ErrNotFound` 등)
+- 변수명은 짧고 관용적으로 (`err`, `ctx`, `req`, `resp`, `c` for echo.Context)
+- 구조체 필드 태그는 `json` 우선 (`validate` 사용처 없음)
+
+---
+
+## 10. 구현 Phase 분해
+
+writing-plans skill로 넘기기 위한 큰 그림. 각 Phase는 독립적으로 검증 가능한 단위.
+
+| Phase | 작업 | TDD | 검증 |
+|---|---|---|---|
+| 0. Scaffold | backend 패키지 init, frontend Vite 셋업, Makefile, README 골격 | — | `go build ./...`, `npm run dev` 부팅 |
+| 1. 도메인 모델 | `todo.go` (Priority, Todo, Validate, NewTodo, Patch, ValidationError, ErrNotFound) | ✅ Red→Green→Refactor | `go test ./backend/todo` |
+| 2. Store | `store.go` (Add/Get/Update/Delete/List, mutex, sort) | ✅ + 동시성 | `go test -race ./backend/todo` |
+| 3. Handler | `handler.go` (List/Create/Update/Delete + writeError) | ✅ httptest 단위 | handler_test 통과 |
+| 4. Server 통합 | `server.go` (Echo, 미들웨어, 라우트) + main.go | 통합 1개 | server_test + `curl /api/health` |
+| 5. FE 인프라 | `types.ts`, `api.ts`, MSW 핸들러, vite proxy | (선택) | `npm run dev` 부팅 + 콘솔 확인 |
+| 6. useTodos hook | reducer + effect + actions | (선택) | hook 단독 테스트 |
+| 7. 컴포넌트 | TodoForm, FilterBar, TodoItem, TodoList | smoke (TodoItem 1개) | App.test에서 통합 검증 |
+| 8. App 통합 | App.tsx 조립 + App.test.tsx (MSW로 풀 시나리오) | ✅ 통합 1개 | `npm test` 통과 |
+| 9. 통합 검증 | Makefile 마무리, README 완성, BE+FE 동시 실행 후 브라우저 CRUD 1 사이클 | — | 사람이 직접 |
+| 10. Code review | `superpowers:requesting-code-review` 호출 | — | 코멘트 반영 |
+
+### 10.1 superpowers skill 활용 매트릭스
+
+| Phase | 트리거되는 skill |
+|---|---|
+| 모든 Phase 시작 | `verification-before-completion` (이전 phase done 정의 만족 확인) |
+| Phase 1, 2, 3, 8 | `test-driven-development` (Red→Green→Refactor 명시 사이클) |
+| Phase 7 (선택) | `dispatching-parallel-agents` (4개 컴포넌트 병렬 worktree) |
+| 임의 phase 중 버그 | `systematic-debugging` (가설 → 격리 → 수정) |
+| Phase 0 (선택) | `using-git-worktrees` (격리된 작업 공간) |
+| Phase 10 | `requesting-code-review` |
+| 전체 진행 | `executing-plans` (이 plan을 따라 phase별 체크포인트) |
+
+### 10.2 Phase 간 검증 게이트
+
+각 phase 완료 선언 전 의무 검증:
+
+- **백엔드 phase**: `cd backend && go test -race ./... && go vet ./...`
+- **프론트 phase**: `cd frontend && npm run build && npm test`
+- **통합 phase**: BE + FE 동시 실행, 브라우저에서 CRUD 1 사이클
+
+---
+
+## 11. 의존성
+
+### 11.1 백엔드
+
+| 패키지 | 용도 |
+|---|---|
+| `github.com/labstack/echo/v4` | 웹 프레임워크 |
+| `github.com/labstack/echo/v4/middleware` | logger, recover, CORS |
+| `github.com/google/uuid` | UUID v4 생성 |
+| `github.com/stretchr/testify/assert` (test only) | 어설션 (프로젝트 컨벤션) |
+
+### 11.2 프론트엔드
+
+| 패키지 | 용도 |
+|---|---|
+| `react`, `react-dom` | 19.x |
+| `vite`, `@vitejs/plugin-react` | 빌드/dev |
+| `typescript` | 5.x |
+| `vitest`, `@vitest/ui` | 테스트 러너 |
+| `@testing-library/react`, `@testing-library/user-event` | 컴포넌트 테스트 |
+| `msw` | API 모킹 |
+| `jsdom` | Vitest DOM 환경 |
+
+---
+
+## 12. 운영 관련 결정 사항
+
+| 항목 | 결정 |
+|---|---|
+| 환경변수 | 사용 안 함. 포트는 코드 상수 + Makefile 변수로만 관리 (학습 노이즈 ↓) |
+| 시작 순서 | BE 먼저, FE는 첫 fetch에서 BE 부재 시 에러 배너. README 명시 |
+| 포트 충돌 | `BE_PORT=8080 FE_PORT=5173` 변수화, README에 변경 방법 명시 |
+| 로깅 | BE는 `middleware.Logger()` 기본, 5xx는 stack trace. FE는 `console.error` 만 |
+| 데이터 영속성 | 없음. 서버 재시작 시 전부 손실 (in-memory). README에 명시. |
+
+---
+
+## 13. 다음 단계
+
+1. 본 spec을 사용자가 검토 → 승인
+2. `superpowers:writing-plans` skill 호출로 위 Phase 분해를 상세 작업 단위 plan으로 변환
+3. plan 작성 완료 후 `superpowers:executing-plans` 또는 `subagent-driven-development` 로 구현 진입

--- a/ai/superpowers/todo/frontend/e2e/todo.spec.ts
+++ b/ai/superpowers/todo/frontend/e2e/todo.spec.ts
@@ -1,0 +1,157 @@
+import { test, expect, type Page, type APIRequestContext } from '@playwright/test'
+
+const API = 'http://localhost:8080/api'
+
+async function clearAllTodos(request: APIRequestContext) {
+  const res = await request.get(`${API}/todos`)
+  const todos = (await res.json()) as Array<{ id: string }>
+  for (const t of todos) {
+    await request.delete(`${API}/todos/${t.id}`)
+  }
+}
+
+async function addTodo(page: Page, title: string, priority: 'low' | 'medium' | 'high' = 'medium') {
+  const titleInput = page.getByLabel('제목')
+  // Wait for previous submit to complete (input becomes empty and button re-enabled)
+  await expect(titleInput).toBeEnabled()
+  await titleInput.fill(title)
+  await page.getByLabel('우선순위', { exact: true }).selectOption(priority)
+  await page.getByRole('button', { name: '추가' }).click()
+  // Wait for the item to appear in the list (confirms network round-trip completed)
+  await expect(page.getByRole('list').getByText(title)).toBeVisible()
+}
+
+test.beforeEach(async ({ page, request }) => {
+  await clearAllTodos(request)
+  await page.goto('/')
+})
+
+test('1. 빈 상태 → 항목 추가 → 목록 등장', async ({ page }) => {
+  await expect(page.getByText('할 일이 없습니다.')).toBeVisible()
+
+  await addTodo(page, '우유 사기', 'high')
+
+  await expect(page.getByText('우유 사기')).toBeVisible()
+  await expect(page.getByRole('list').getByText('높음')).toBeVisible()
+  await expect(page.getByText('할 일이 없습니다.')).not.toBeVisible()
+})
+
+test('2. 완료 토글 → 체크박스 상태 + BE 반영', async ({ page, request }) => {
+  await addTodo(page, '운동하기')
+  const checkbox = page.getByRole('checkbox', { name: /완료/ })
+  await expect(checkbox).not.toBeChecked()
+
+  await checkbox.click()
+  await expect(checkbox).toBeChecked()
+
+  // BE 검증
+  const res = await request.get(`${API}/todos`)
+  const todos = (await res.json()) as Array<{ title: string; completed: boolean }>
+  expect(todos).toHaveLength(1)
+  expect(todos[0].completed).toBe(true)
+})
+
+test('3. 필터 (전체/미완료/완료) 전환', async ({ page }) => {
+  await addTodo(page, '활성 항목')
+  await addTodo(page, '완료 항목')
+  // '완료 항목'을 완료 처리 — li 기준으로 체크박스를 찾아서 클릭
+  const completedItem = page.getByRole('list').locator('li').filter({ hasText: '완료 항목' })
+  const completedCheckbox = completedItem.getByRole('checkbox')
+  await completedCheckbox.click()
+  await expect(completedCheckbox).toBeChecked()
+
+  // 미완료 필터: "활성 항목"만
+  await page.getByRole('radio', { name: '미완료', exact: true }).click()
+  await expect(page.getByRole('list').getByText('활성 항목')).toBeVisible()
+  await expect(page.getByRole('list').getByText('완료 항목')).not.toBeVisible()
+
+  // 완료 필터: "완료 항목"만
+  await page.getByRole('radio', { name: '완료', exact: true }).click()
+  await expect(page.getByRole('list').getByText('완료 항목')).toBeVisible()
+  await expect(page.getByRole('list').getByText('활성 항목')).not.toBeVisible()
+
+  // 전체로 복귀
+  await page.getByRole('radio', { name: '전체', exact: true }).click()
+  await expect(page.getByRole('list').getByText('활성 항목')).toBeVisible()
+  await expect(page.getByRole('list').getByText('완료 항목')).toBeVisible()
+})
+
+test('4. 인라인 편집: 제목 클릭 → 수정 → blur 저장', async ({ page, request }) => {
+  await addTodo(page, '원본 제목')
+  await page.getByText('원본 제목').click()
+
+  const editor = page.getByLabel('제목 편집')
+  await editor.fill('수정된 제목')
+  await editor.blur()
+
+  await expect(page.getByText('수정된 제목')).toBeVisible()
+  await expect(page.getByText('원본 제목')).not.toBeVisible()
+
+  // BE 검증
+  const res = await request.get(`${API}/todos`)
+  const todos = (await res.json()) as Array<{ title: string }>
+  expect(todos[0].title).toBe('수정된 제목')
+})
+
+test('5. 인라인 편집 Escape 시 원복', async ({ page }) => {
+  await addTodo(page, '원본')
+  await page.getByText('원본').click()
+  const editor = page.getByLabel('제목 편집')
+  await editor.fill('취소될 값')
+  await editor.press('Escape')
+  await expect(page.getByText('원본')).toBeVisible()
+  await expect(page.getByText('취소될 값')).not.toBeVisible()
+})
+
+test('6. 정렬 토글 (asc ↔ desc)', async ({ page }) => {
+  await addTodo(page, '첫 번째')
+  await addTodo(page, '두 번째')
+  // 기본은 createdAt desc → 두 번째가 먼저
+  await expect(page.locator('li').first()).toContainText('두 번째')
+  await expect(page.locator('li').nth(1)).toContainText('첫 번째')
+
+  // asc로 토글
+  await page.getByRole('button', { name: '정렬 방향 토글' }).click()
+  // Wait for order to flip before reading
+  await expect(page.locator('li').first()).toContainText('첫 번째')
+  await expect(page.locator('li').nth(1)).toContainText('두 번째')
+})
+
+test('7. 삭제 → 빈 상태 복귀', async ({ page }) => {
+  await addTodo(page, '삭제 예정')
+  await expect(page.getByText('삭제 예정')).toBeVisible()
+
+  await page.getByRole('button', { name: '삭제' }).click()
+
+  await expect(page.getByText('삭제 예정')).not.toBeVisible()
+  await expect(page.getByText('할 일이 없습니다.')).toBeVisible()
+})
+
+test('8. API 실패 시 에러 배너 표시', async ({ page }) => {
+  // route 가로채기로 BE 응답을 강제 실패
+  await page.route('**/api/todos*', (route) => {
+    if (route.request().method() === 'GET') {
+      return route.abort('failed')
+    }
+    return route.continue()
+  })
+  await page.reload()
+  await expect(page.getByRole('alert')).toBeVisible()
+})
+
+test('9. priority 정렬 (high → low)', async ({ page }) => {
+  await addTodo(page, '낮음 항목', 'low')
+  await addTodo(page, '높음 항목', 'high')
+  await addTodo(page, '보통 항목', 'medium')
+
+  // priority 정렬로 변경 (sort select is inside the toolbar)
+  const sortSelect = page.getByRole('toolbar').locator('select')
+  await sortSelect.selectOption('priority')
+  // 현재 desc이므로 high가 먼저
+  await expect(page.locator('li').first()).toContainText('높음 항목')
+
+  // asc로 토글 → low가 먼저
+  await page.getByRole('button', { name: '정렬 방향 토글' }).click()
+  await expect(page.locator('li').first()).toContainText('낮음 항목')
+  await expect(page.locator('li').nth(2)).toContainText('높음 항목')
+})

--- a/ai/superpowers/todo/frontend/index.html
+++ b/ai/superpowers/todo/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Superpowers Todo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/ai/superpowers/todo/frontend/package-lock.json
+++ b/ai/superpowers/todo/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "react-dom": "^19.0.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.53.1",
         "@testing-library/react": "^16.0.0",
         "@testing-library/user-event": "^14.5.0",
         "@types/react": "^19.0.0",
@@ -1029,6 +1030,22 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.1.tgz",
+      "integrity": "sha512-Z4c23LHV0muZ8hfv4jw6HngPJkbbtZxTkxPNIg7cJcTc9C28N/p2q7g3JZS2SiKBBHJ3uM1dgDye66bB7LEk5w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.53.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
@@ -2809,6 +2826,53 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.1.tgz",
+      "integrity": "sha512-LJ13YLr/ocweuwxyGf1XNFWIU4M2zUSo149Qbp+A4cpwDjsxRPj7k6H25LBrEHiEwxvRbD8HdwvQmRMSvquhYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.53.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.1.tgz",
+      "integrity": "sha512-Z46Oq7tLAyT0lGoFx4DOuB1IA9D1TPj0QkYxpPVUnGDqHHvDpCftu1J2hM2PiWsNMoZh8+LQaarAWcDfPBc6zg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.12",

--- a/ai/superpowers/todo/frontend/package-lock.json
+++ b/ai/superpowers/todo/frontend/package-lock.json
@@ -1,0 +1,3694 @@
+{
+  "name": "superpowers-todo-frontend",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "superpowers-todo-frontend",
+      "version": "0.0.0",
+      "dependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      },
+      "devDependencies": {
+        "@testing-library/react": "^16.0.0",
+        "@testing-library/user-event": "^14.5.0",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "@vitejs/plugin-react": "^4.3.0",
+        "jsdom": "^24.0.0",
+        "msw": "^2.4.0",
+        "typescript": "^5.5.0",
+        "vite": "^5.4.0",
+        "vitest": "^2.1.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.5.tgz",
+      "integrity": "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.12.tgz",
+      "integrity": "sha512-h9FgGun3QwVYNj5TWIZZ+slii73bMoBFjPfVIGtnFuL4t8gBiNDV9PcSfIzkuxvgquJKt9nr1QzszpBzTbH8Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.9",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.1.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.9.tgz",
+      "integrity": "sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.5.tgz",
+      "integrity": "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
+      "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.7",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.7.tgz",
+      "integrity": "sha512-D0nkS5+sx87mYpxFqASImCineYoEl9wGlUPrzkuS0ohzG8wfophLpE+I76qGJ0slLAVI19do5SI9pWJNCVf4fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mswjs/interceptors/node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-3.0.0.tgz",
+      "integrity": "sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/set-cookie-parser": {
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.10.tgz",
+      "integrity": "sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.24",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz",
+      "integrity": "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.345",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.345.tgz",
+      "integrity": "sha512-F9JXQGiMrz6yVNPI2qOVPvB9HzjH5cGzhs8oJ6A28V5L/YnzN/0KsuiibqF+F1Fd9qxFzD1BUnYSd8JfULxTwg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
+      "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graphql": {
+      "version": "16.13.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
+      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-5.0.1.tgz",
+      "integrity": "sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/set-cookie-parser": "^2.4.10",
+        "set-cookie-parser": "^3.0.1"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
+      "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.4",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/msw": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.14.2.tgz",
+      "integrity": "sha512-D2bTe0tpuf9nw4DA39wFaqUD/hRPKj0DKpo2lAqu+A47Ifg4+h0hbfn6QxVOsiUY2uhgEN6TTpGSHDsc+ysYNg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/confirm": "^6.0.11",
+        "@mswjs/interceptors": "^0.41.3",
+        "@open-draft/deferred-promise": "^3.0.0",
+        "@types/statuses": "^2.0.6",
+        "cookie": "^1.1.1",
+        "graphql": "^16.13.2",
+        "headers-polyfill": "^5.0.1",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "rettime": "^0.11.7",
+        "statuses": "^2.0.2",
+        "strict-event-emitter": "^0.5.1",
+        "tough-cookie": "^6.0.1",
+        "type-fest": "^5.5.0",
+        "until-async": "^3.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.5"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rettime": {
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.8.tgz",
+      "integrity": "sha512-0fERGXktJTyJ+h8fBEiPxHPEFOu0h15JY7JtwrOVqR5K+vb99ho6IyOo7ekLS3h4sJCzIDy4VWKIbZUfe9njmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
+      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.29.tgz",
+      "integrity": "sha512-JIXCerhudr/N6OWLwLF1HVsTTUo7ry6qHa5eWZEkiMuxsIiAACL55tGLfqfHfoH7QaMQUW8fngD7u7TxWexYQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.29"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.29.tgz",
+      "integrity": "sha512-W99NuU7b1DcG3uJ3v9k9VztCH3WialNbBkBft5wCs8V8mexu0XQqaZEYb9l9RNNzK8+3EJ9PKWB0/RUtTQ/o+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/until-async": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
+      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/ai/superpowers/todo/frontend/package.json
+++ b/ai/superpowers/todo/frontend/package.json
@@ -7,13 +7,16 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.53.1",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.0",
     "@types/react": "^19.0.0",

--- a/ai/superpowers/todo/frontend/package.json
+++ b/ai/superpowers/todo/frontend/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "superpowers-todo-frontend",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.5.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.3.0",
+    "jsdom": "^24.0.0",
+    "msw": "^2.4.0",
+    "typescript": "^5.5.0",
+    "vite": "^5.4.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/ai/superpowers/todo/frontend/playwright.config.ts
+++ b/ai/superpowers/todo/frontend/playwright.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const PORT_FE = 5173
+const PORT_BE = 8080
+const BASE_URL = `http://localhost:${PORT_FE}`
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false, // 단일 in-memory store를 공유하므로 직렬 실행
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: [['list']],
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+  webServer: [
+    {
+      command: 'cd ../backend && go run .',
+      port: PORT_BE,
+      reuseExistingServer: !process.env.CI,
+      timeout: 30_000,
+    },
+    {
+      command: 'npm run dev',
+      port: PORT_FE,
+      reuseExistingServer: !process.env.CI,
+      timeout: 30_000,
+    },
+  ],
+})

--- a/ai/superpowers/todo/frontend/src/App.tsx
+++ b/ai/superpowers/todo/frontend/src/App.tsx
@@ -1,3 +1,23 @@
+import { useState } from 'react'
+import { useTodos } from './hooks/useTodos'
+import { TodoForm } from './components/TodoForm'
+import { FilterBar } from './components/FilterBar'
+import { TodoList } from './components/TodoList'
+import type { Query } from './types'
+
+const defaultQuery: Query = { status: 'all', sort: 'createdAt', order: 'desc' }
+
 export default function App() {
-  return <h1>Superpowers Todo (work in progress)</h1>
+  const [query, setQuery] = useState<Query>(defaultQuery)
+  const { todos, error, create, update, remove } = useTodos(query)
+
+  return (
+    <main>
+      <h1>Superpowers Todo</h1>
+      {error && <div role="alert">에러: {error}</div>}
+      <TodoForm onCreate={create} />
+      <FilterBar query={query} onChange={setQuery} />
+      <TodoList todos={todos} onUpdate={update} onRemove={remove} />
+    </main>
+  )
 }

--- a/ai/superpowers/todo/frontend/src/App.tsx
+++ b/ai/superpowers/todo/frontend/src/App.tsx
@@ -1,0 +1,3 @@
+export default function App() {
+  return <h1>Superpowers Todo (work in progress)</h1>
+}

--- a/ai/superpowers/todo/frontend/src/__tests__/App.test.tsx
+++ b/ai/superpowers/todo/frontend/src/__tests__/App.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import App from '../App'
+import { server } from './mocks/server'
+import { http, HttpResponse } from 'msw'
+
+describe('App 통합 시나리오', () => {
+  it('빈 상태 → 추가 → 토글 → 삭제', async () => {
+    render(<App />)
+    await waitFor(() => expect(screen.getByText('할 일이 없습니다.')).toBeDefined())
+
+    // 추가
+    await userEvent.type(screen.getByRole('textbox', { name: '제목' }), '우유 사기')
+    await userEvent.click(screen.getByRole('button', { name: '추가' }))
+    await waitFor(() => expect(screen.getByText('우유 사기')).toBeDefined())
+
+    // 완료 토글
+    await userEvent.click(screen.getByRole('checkbox', { name: /완료/ }))
+    await waitFor(() => {
+      const cb = screen.getByRole('checkbox', { name: /완료/ }) as HTMLInputElement
+      expect(cb.checked).toBe(true)
+    })
+
+    // 삭제
+    await userEvent.click(screen.getByRole('button', { name: '삭제' }))
+    await waitFor(() => expect(screen.getByText('할 일이 없습니다.')).toBeDefined())
+  })
+
+  it('네트워크 실패 시 에러 배너 표시', async () => {
+    server.use(http.get('/api/todos', () => HttpResponse.error()))
+    render(<App />)
+    await waitFor(() => expect(screen.getByRole('alert')).toBeDefined())
+  })
+})

--- a/ai/superpowers/todo/frontend/src/__tests__/TodoItem.test.tsx
+++ b/ai/superpowers/todo/frontend/src/__tests__/TodoItem.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { TodoItem } from '../components/TodoItem'
+import type { Todo } from '../types'
+
+function makeTodo(overrides: Partial<Todo> = {}): Todo {
+  return {
+    id: 'id1',
+    title: '할일 1',
+    completed: false,
+    priority: 'high',
+    dueDate: null,
+    createdAt: '2026-04-30T10:00:00Z',
+    updatedAt: '2026-04-30T10:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('TodoItem', () => {
+  it('priority 뱃지 표시', () => {
+    render(<TodoItem todo={makeTodo({ priority: 'high' })} onUpdate={vi.fn()} onRemove={vi.fn()} />)
+    expect(screen.getByText('높음')).toBeDefined()
+  })
+
+  it('dueDate 표시 (있을 때만)', () => {
+    const { rerender } = render(
+      <TodoItem todo={makeTodo({ dueDate: null })} onUpdate={vi.fn()} onRemove={vi.fn()} />,
+    )
+    expect(screen.queryByText(/마감/)).toBeNull()
+
+    rerender(
+      <TodoItem
+        todo={makeTodo({ dueDate: '2026-05-15T18:00:00Z' })}
+        onUpdate={vi.fn()}
+        onRemove={vi.fn()}
+      />,
+    )
+    expect(screen.getByText(/마감/)).toBeDefined()
+  })
+
+  it('체크박스 클릭 시 onUpdate 호출', async () => {
+    const onUpdate = vi.fn().mockResolvedValue(undefined)
+    render(<TodoItem todo={makeTodo()} onUpdate={onUpdate} onRemove={vi.fn()} />)
+    const cb = screen.getByRole('checkbox', { name: /완료/ })
+    await userEvent.click(cb)
+    expect(onUpdate).toHaveBeenCalledWith('id1', { completed: true })
+  })
+
+  it('삭제 버튼 클릭 시 onRemove 호출', async () => {
+    const onRemove = vi.fn().mockResolvedValue(undefined)
+    render(<TodoItem todo={makeTodo()} onUpdate={vi.fn()} onRemove={onRemove} />)
+    await userEvent.click(screen.getByRole('button', { name: /삭제/ }))
+    expect(onRemove).toHaveBeenCalledWith('id1')
+  })
+
+  it('제목 클릭 → 편집 → blur 시 onUpdate 호출', async () => {
+    const onUpdate = vi.fn().mockResolvedValue(undefined)
+    render(<TodoItem todo={makeTodo()} onUpdate={onUpdate} onRemove={vi.fn()} />)
+    const title = screen.getByText('할일 1')
+    await userEvent.click(title)
+    const input = screen.getByRole('textbox', { name: /제목/ })
+    await userEvent.clear(input)
+    await userEvent.type(input, '수정됨')
+    input.blur()
+    expect(onUpdate).toHaveBeenCalledWith('id1', { title: '수정됨' })
+  })
+})

--- a/ai/superpowers/todo/frontend/src/__tests__/mocks/handlers.ts
+++ b/ai/superpowers/todo/frontend/src/__tests__/mocks/handlers.ts
@@ -1,0 +1,76 @@
+import { http, HttpResponse } from 'msw'
+import type { Todo, NewTodo, Patch } from '../../types'
+
+let todos: Todo[] = []
+
+function uid(): string {
+  return Math.random().toString(36).slice(2) + Date.now().toString(36)
+}
+
+export function resetMockTodos(seed: Todo[] = []) {
+  todos = seed.map((t) => ({ ...t }))
+}
+
+export const handlers = [
+  http.get('/api/health', () => HttpResponse.json({ status: 'ok' })),
+
+  http.get('/api/todos', ({ request }) => {
+    const url = new URL(request.url)
+    const status = url.searchParams.get('status') ?? 'all'
+    let out = [...todos]
+    if (status === 'active') out = out.filter((t) => !t.completed)
+    if (status === 'completed') out = out.filter((t) => t.completed)
+    return HttpResponse.json(out)
+  }),
+
+  http.post('/api/todos', async ({ request }) => {
+    const body = (await request.json()) as NewTodo
+    if (!body.title?.trim()) {
+      return HttpResponse.json(
+        { error: { code: 'validation_failed', message: 'title is required', details: { field: 'title' } } },
+        { status: 400 },
+      )
+    }
+    const now = new Date().toISOString()
+    const created: Todo = {
+      id: uid(),
+      title: body.title.trim(),
+      completed: false,
+      priority: body.priority ?? 'medium',
+      dueDate: body.dueDate ?? null,
+      createdAt: now,
+      updatedAt: now,
+    }
+    todos.push(created)
+    return HttpResponse.json(created, { status: 201 })
+  }),
+
+  http.patch('/api/todos/:id', async ({ params, request }) => {
+    const id = params.id as string
+    const idx = todos.findIndex((t) => t.id === id)
+    if (idx === -1) {
+      return HttpResponse.json(
+        { error: { code: 'not_found', message: 'todo not found' } },
+        { status: 404 },
+      )
+    }
+    const patch = (await request.json()) as Patch
+    const t = { ...todos[idx], ...patch, updatedAt: new Date().toISOString() }
+    if ('dueDate' in patch && patch.dueDate === null) t.dueDate = null
+    todos[idx] = t
+    return HttpResponse.json(t)
+  }),
+
+  http.delete('/api/todos/:id', ({ params }) => {
+    const id = params.id as string
+    const before = todos.length
+    todos = todos.filter((t) => t.id !== id)
+    if (todos.length === before) {
+      return HttpResponse.json(
+        { error: { code: 'not_found', message: 'todo not found' } },
+        { status: 404 },
+      )
+    }
+    return new HttpResponse(null, { status: 204 })
+  }),
+]

--- a/ai/superpowers/todo/frontend/src/__tests__/mocks/server.ts
+++ b/ai/superpowers/todo/frontend/src/__tests__/mocks/server.ts
@@ -1,0 +1,4 @@
+import { setupServer } from 'msw/node'
+import { handlers } from './handlers'
+
+export const server = setupServer(...handlers)

--- a/ai/superpowers/todo/frontend/src/__tests__/setup.ts
+++ b/ai/superpowers/todo/frontend/src/__tests__/setup.ts
@@ -1,2 +1,11 @@
-// Phase 5에서 MSW server 등록 추가됨.
-// 현재는 testing-library 자동 cleanup만 활성화 (vitest globals + jsdom으로 충분).
+import { afterAll, afterEach, beforeAll } from 'vitest'
+import '@testing-library/react'
+import { server } from './mocks/server'
+import { resetMockTodos } from './mocks/handlers'
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => {
+  server.resetHandlers()
+  resetMockTodos([])
+})
+afterAll(() => server.close())

--- a/ai/superpowers/todo/frontend/src/__tests__/setup.ts
+++ b/ai/superpowers/todo/frontend/src/__tests__/setup.ts
@@ -1,0 +1,2 @@
+// Phase 5에서 MSW server 등록 추가됨.
+// 현재는 testing-library 자동 cleanup만 활성화 (vitest globals + jsdom으로 충분).

--- a/ai/superpowers/todo/frontend/src/__tests__/useTodos.test.ts
+++ b/ai/superpowers/todo/frontend/src/__tests__/useTodos.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { useTodos } from '../hooks/useTodos'
+import { resetMockTodos } from './mocks/handlers'
+import type { Query } from '../types'
+
+const defaultQuery: Query = { status: 'all', sort: 'createdAt', order: 'desc' }
+
+describe('useTodos', () => {
+  it('초기 fetch 후 todos 채워짐', async () => {
+    resetMockTodos([
+      {
+        id: '1',
+        title: 'seeded',
+        completed: false,
+        priority: 'medium',
+        dueDate: null,
+        createdAt: '2026-04-01T00:00:00Z',
+        updatedAt: '2026-04-01T00:00:00Z',
+      },
+    ])
+    const { result } = renderHook(() => useTodos(defaultQuery))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.todos).toHaveLength(1)
+    expect(result.current.todos[0].title).toBe('seeded')
+  })
+
+  it('create 후 list refetch', async () => {
+    const { result } = renderHook(() => useTodos(defaultQuery))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.todos).toHaveLength(0)
+
+    await act(async () => {
+      await result.current.create({ title: '새 할일' })
+    })
+    await waitFor(() => expect(result.current.todos).toHaveLength(1))
+    expect(result.current.todos[0].title).toBe('새 할일')
+  })
+
+  it('update 후 list refetch', async () => {
+    const { result } = renderHook(() => useTodos(defaultQuery))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    await act(async () => {
+      await result.current.create({ title: 'x' })
+    })
+    await waitFor(() => expect(result.current.todos).toHaveLength(1))
+    const id = result.current.todos[0].id
+
+    await act(async () => {
+      await result.current.update(id, { completed: true })
+    })
+    await waitFor(() => expect(result.current.todos[0].completed).toBe(true))
+  })
+
+  it('remove 후 목록에서 제거', async () => {
+    const { result } = renderHook(() => useTodos(defaultQuery))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    await act(async () => {
+      await result.current.create({ title: 'x' })
+    })
+    await waitFor(() => expect(result.current.todos).toHaveLength(1))
+    const id = result.current.todos[0].id
+
+    await act(async () => {
+      await result.current.remove(id)
+    })
+    await waitFor(() => expect(result.current.todos).toHaveLength(0))
+  })
+
+  it('네트워크 실패 시 error 상태', async () => {
+    const { server } = await import('./mocks/server')
+    const { http, HttpResponse } = await import('msw')
+    server.use(http.get('/api/todos', () => HttpResponse.error()))
+
+    const { result } = renderHook(() => useTodos(defaultQuery))
+    await waitFor(() => expect(result.current.error).not.toBeNull())
+    expect(result.current.loading).toBe(false)
+  })
+})

--- a/ai/superpowers/todo/frontend/src/api.ts
+++ b/ai/superpowers/todo/frontend/src/api.ts
@@ -1,0 +1,42 @@
+import type { NewTodo, Patch, Query, Todo } from './types'
+
+const BASE = '/api'
+
+export class ApiError extends Error {
+  constructor(public code: string, message: string) {
+    super(message)
+    this.name = 'ApiError'
+  }
+}
+
+async function call<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(BASE + path, {
+    ...init,
+    headers: { 'Content-Type': 'application/json', ...(init?.headers ?? {}) },
+  })
+  if (!res.ok) {
+    let code = 'unknown'
+    let message = res.statusText
+    try {
+      const body = (await res.json()) as { error?: { code?: string; message?: string } }
+      code = body.error?.code ?? code
+      message = body.error?.message ?? message
+    } catch {
+      // body가 JSON이 아닐 수 있음. statusText 그대로 사용.
+    }
+    throw new ApiError(code, message)
+  }
+  if (res.status === 204) return undefined as T
+  return (await res.json()) as T
+}
+
+export const api = {
+  list: (q: Query) =>
+    call<Todo[]>(`/todos?${new URLSearchParams(q as unknown as Record<string, string>)}`),
+  create: (input: NewTodo) =>
+    call<Todo>('/todos', { method: 'POST', body: JSON.stringify(input) }),
+  update: (id: string, patch: Patch) =>
+    call<Todo>(`/todos/${id}`, { method: 'PATCH', body: JSON.stringify(patch) }),
+  remove: (id: string) =>
+    call<void>(`/todos/${id}`, { method: 'DELETE' }),
+}

--- a/ai/superpowers/todo/frontend/src/components/FilterBar.tsx
+++ b/ai/superpowers/todo/frontend/src/components/FilterBar.tsx
@@ -1,0 +1,46 @@
+import type { Order, Query, SortKey, Status } from '../types'
+
+interface Props {
+  query: Query
+  onChange: (next: Query) => void
+}
+
+export function FilterBar({ query, onChange }: Props) {
+  return (
+    <div role="toolbar" aria-label="필터/정렬">
+      <fieldset>
+        <legend>상태</legend>
+        {(['all', 'active', 'completed'] as Status[]).map((s) => (
+          <label key={s}>
+            <input
+              type="radio"
+              name="status"
+              value={s}
+              checked={query.status === s}
+              onChange={() => onChange({ ...query, status: s })}
+            />
+            {s === 'all' ? '전체' : s === 'active' ? '미완료' : '완료'}
+          </label>
+        ))}
+      </fieldset>
+      <label>
+        정렬
+        <select
+          value={query.sort}
+          onChange={(e) => onChange({ ...query, sort: e.target.value as SortKey })}
+        >
+          <option value="createdAt">생성일</option>
+          <option value="dueDate">마감일</option>
+          <option value="priority">우선순위</option>
+        </select>
+      </label>
+      <button
+        type="button"
+        aria-label="정렬 방향 토글"
+        onClick={() => onChange({ ...query, order: (query.order === 'asc' ? 'desc' : 'asc') as Order })}
+      >
+        {query.order === 'asc' ? '↑' : '↓'}
+      </button>
+    </div>
+  )
+}

--- a/ai/superpowers/todo/frontend/src/components/TodoForm.tsx
+++ b/ai/superpowers/todo/frontend/src/components/TodoForm.tsx
@@ -1,0 +1,59 @@
+import { useState, type FormEvent } from 'react'
+import type { NewTodo, Priority } from '../types'
+
+interface Props {
+  onCreate: (input: NewTodo) => Promise<void>
+}
+
+export function TodoForm({ onCreate }: Props) {
+  const [title, setTitle] = useState('')
+  const [priority, setPriority] = useState<Priority>('medium')
+  const [dueDate, setDueDate] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  const submit = async (e: FormEvent) => {
+    e.preventDefault()
+    if (!title.trim() || submitting) return
+    setSubmitting(true)
+    try {
+      await onCreate({
+        title: title.trim(),
+        priority,
+        dueDate: dueDate ? new Date(dueDate).toISOString() : undefined,
+      })
+      setTitle('')
+      setDueDate('')
+      setPriority('medium')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <form onSubmit={submit} aria-label="새 할일 추가">
+      <input
+        aria-label="제목"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="할 일 입력..."
+        maxLength={200}
+      />
+      <select
+        aria-label="우선순위"
+        value={priority}
+        onChange={(e) => setPriority(e.target.value as Priority)}
+      >
+        <option value="low">낮음</option>
+        <option value="medium">보통</option>
+        <option value="high">높음</option>
+      </select>
+      <input
+        aria-label="마감일"
+        type="datetime-local"
+        value={dueDate}
+        onChange={(e) => setDueDate(e.target.value)}
+      />
+      <button type="submit" disabled={!title.trim() || submitting}>추가</button>
+    </form>
+  )
+}

--- a/ai/superpowers/todo/frontend/src/components/TodoItem.tsx
+++ b/ai/superpowers/todo/frontend/src/components/TodoItem.tsx
@@ -1,0 +1,60 @@
+import { useState, type KeyboardEvent } from 'react'
+import type { Patch, Priority, Todo } from '../types'
+
+interface Props {
+  todo: Todo
+  onUpdate: (id: string, patch: Patch) => Promise<void>
+  onRemove: (id: string) => Promise<void>
+}
+
+const priorityLabel: Record<Priority, string> = { low: '낮음', medium: '보통', high: '높음' }
+
+export function TodoItem({ todo, onUpdate, onRemove }: Props) {
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(todo.title)
+
+  const commit = () => {
+    setEditing(false)
+    const next = draft.trim()
+    if (next && next !== todo.title) {
+      void onUpdate(todo.id, { title: next })
+    } else {
+      setDraft(todo.title)
+    }
+  }
+
+  const onKey = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.currentTarget.blur()
+    } else if (e.key === 'Escape') {
+      setDraft(todo.title)
+      setEditing(false)
+    }
+  }
+
+  return (
+    <li>
+      <input
+        type="checkbox"
+        aria-label="완료"
+        checked={todo.completed}
+        onChange={(e) => onUpdate(todo.id, { completed: e.target.checked })}
+      />
+      {editing ? (
+        <input
+          aria-label="제목 편집"
+          value={draft}
+          autoFocus
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commit}
+          onKeyDown={onKey}
+        />
+      ) : (
+        <span onClick={() => setEditing(true)}>{todo.title}</span>
+      )}
+      <span data-priority={todo.priority}>{priorityLabel[todo.priority]}</span>
+      {todo.dueDate && <span>마감: {new Date(todo.dueDate).toLocaleString()}</span>}
+      <button type="button" aria-label="삭제" onClick={() => onRemove(todo.id)}>×</button>
+    </li>
+  )
+}

--- a/ai/superpowers/todo/frontend/src/components/TodoList.tsx
+++ b/ai/superpowers/todo/frontend/src/components/TodoList.tsx
@@ -1,0 +1,21 @@
+import type { Patch, Todo } from '../types'
+import { TodoItem } from './TodoItem'
+
+interface Props {
+  todos: Todo[]
+  onUpdate: (id: string, patch: Patch) => Promise<void>
+  onRemove: (id: string) => Promise<void>
+}
+
+export function TodoList({ todos, onUpdate, onRemove }: Props) {
+  if (todos.length === 0) {
+    return <p>할 일이 없습니다.</p>
+  }
+  return (
+    <ul aria-label="할 일 목록">
+      {todos.map((t) => (
+        <TodoItem key={t.id} todo={t} onUpdate={onUpdate} onRemove={onRemove} />
+      ))}
+    </ul>
+  )
+}

--- a/ai/superpowers/todo/frontend/src/hooks/useTodos.ts
+++ b/ai/superpowers/todo/frontend/src/hooks/useTodos.ts
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useReducer, useRef } from 'react'
+import { api, ApiError } from '../api'
+import type { NewTodo, Patch, Query, Todo } from '../types'
+
+type State = {
+  todos: Todo[]
+  loading: boolean
+  error: string | null
+}
+
+type Action =
+  | { type: 'fetch_start' }
+  | { type: 'fetch_success'; todos: Todo[] }
+  | { type: 'fetch_error'; error: string }
+
+const initial: State = { todos: [], loading: false, error: null }
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'fetch_start':
+      return { ...state, loading: true, error: null }
+    case 'fetch_success':
+      return { todos: action.todos, loading: false, error: null }
+    case 'fetch_error':
+      return { ...state, loading: false, error: action.error }
+  }
+}
+
+export function useTodos(query: Query) {
+  const [state, dispatch] = useReducer(reducer, initial)
+  const queryRef = useRef(query)
+  queryRef.current = query
+
+  const refetch = useCallback(async () => {
+    dispatch({ type: 'fetch_start' })
+    try {
+      const todos = await api.list(queryRef.current)
+      dispatch({ type: 'fetch_success', todos })
+    } catch (e) {
+      const msg =
+        e instanceof ApiError
+          ? e.message
+          : e instanceof Error
+            ? e.message
+            : '서버에 연결할 수 없습니다'
+      dispatch({ type: 'fetch_error', error: msg })
+    }
+  }, [])
+
+  useEffect(() => {
+    void refetch()
+  }, [query.status, query.sort, query.order, refetch])
+
+  const create = useCallback(
+    async (input: NewTodo) => {
+      await api.create(input)
+      await refetch()
+    },
+    [refetch],
+  )
+
+  const update = useCallback(
+    async (id: string, patch: Patch) => {
+      await api.update(id, patch)
+      await refetch()
+    },
+    [refetch],
+  )
+
+  const remove = useCallback(
+    async (id: string) => {
+      await api.remove(id)
+      await refetch()
+    },
+    [refetch],
+  )
+
+  return { ...state, create, update, remove, refetch }
+}

--- a/ai/superpowers/todo/frontend/src/index.css
+++ b/ai/superpowers/todo/frontend/src/index.css
@@ -1,0 +1,11 @@
+:root {
+  font-family: system-ui, -apple-system, sans-serif;
+  color-scheme: light dark;
+}
+
+body {
+  margin: 0;
+  padding: 1rem;
+  max-width: 640px;
+  margin-inline: auto;
+}

--- a/ai/superpowers/todo/frontend/src/main.tsx
+++ b/ai/superpowers/todo/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)

--- a/ai/superpowers/todo/frontend/src/types.ts
+++ b/ai/superpowers/todo/frontend/src/types.ts
@@ -1,0 +1,39 @@
+// 본 파일은 backend/todo/todo.go와 수동 동기화한다.
+// BE 모델 변경 시 같이 수정 (CLAUDE.md 정책).
+
+export type Priority = 'low' | 'medium' | 'high'
+
+export type Status = 'all' | 'active' | 'completed'
+
+export type SortKey = 'createdAt' | 'dueDate' | 'priority'
+
+export type Order = 'asc' | 'desc'
+
+export interface Todo {
+  id: string
+  title: string
+  completed: boolean
+  priority: Priority
+  dueDate: string | null // RFC3339 또는 null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface NewTodo {
+  title: string
+  priority?: Priority
+  dueDate?: string | null
+}
+
+export interface Patch {
+  title?: string
+  completed?: boolean
+  priority?: Priority
+  dueDate?: string | null // null이면 명시적 클리어
+}
+
+export interface Query {
+  status: Status
+  sort: SortKey
+  order: Order
+}

--- a/ai/superpowers/todo/frontend/tsconfig.json
+++ b/ai/superpowers/todo/frontend/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/ai/superpowers/todo/frontend/tsconfig.node.json
+++ b/ai/superpowers/todo/frontend/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "strict": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/ai/superpowers/todo/frontend/vite.config.ts
+++ b/ai/superpowers/todo/frontend/vite.config.ts
@@ -1,0 +1,22 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: false,
+      },
+    },
+  },
+  preview: { port: 4173 },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./src/__tests__/setup.ts'],
+  },
+})


### PR DESCRIPTION
## Summary

학습용 Todo 웹 애플리케이션을 `tutorials-go/ai/superpowers/todo/`에 추가합니다. superpowers plugin skill 사이클(brainstorm → write-plan → subagent-driven TDD → code-review)을 풀로 체험하기 위한 샘플입니다.

- **Backend**: Go 1.26 / Echo v4 / in-memory `Store` (`sync.RWMutex`)
- **Frontend**: React 19 / Vite / TypeScript / `useReducer` 기반 hook
- **두 프로세스 분리**: BE `:8080`, FE `:5173` (Vite proxy `/api/*` → 8080)
- **Spec / Plan**: `ai/superpowers/todo/docs/superpowers/{specs,plans}/2026-04-30-*`

## 주요 기능

- Todo CRUD (생성/조회/수정/삭제/완료 토글)
- 상태 필터 (`all` / `active` / `completed`)
- 우선순위 (`low` / `medium` / `high`), 마감일 (옵셔널 RFC3339)
- 정렬 (생성일 / 마감일 / 우선순위) × asc/desc, nil dueDate는 항상 마지막
- 인라인 제목 편집 (클릭→input, blur/Enter 저장, Escape 취소)
- 서버 사이드 필터링/정렬 (쿼리 파라미터), CORS는 `:5173`/`:4173` 허용

## 설계상 결정 (의도적 단순화)

- 데이터 영속성 없음 (in-memory) — 서버 재시작 시 전부 손실
- 인증/계정 없음
- mutation 후 client는 항상 list refetch (서버 사이드 정렬 정합성 유지)
- types.ts ↔ Go struct 수기 동기화 (codegen 미도입)
- PATCH는 `dueDate` 만 `null` 허용(클리어), 그 외 필드 `null`은 400 validation_failed

## Test plan

- [ ] `cd ai/superpowers/todo/backend && go test -race ./... && go vet ./...` — backend 단위/통합 테스트 (~48개)
- [ ] `cd ai/superpowers/todo/frontend && npm install && npm test -- --run` — frontend 12개 (TodoItem 5 + useTodos 5 + App 통합 2)
- [ ] `cd ai/superpowers/todo/frontend && npm run build` — 프로덕션 빌드
- [ ] BE 단독 검증: `make dev-be`, README의 curl 시나리오 수행
- [ ] BE+FE 통합 (브라우저): `make dev-be` + `make dev-fe`, http://localhost:5173 접속 후 CRUD 1 사이클 + 필터/정렬/인라인편집/삭제 + BE 종료 시 에러 배너 확인

## Follow-ups (병합 후 정리 예정)

최종 코드 리뷰에서 나온 minor 항목들 (모두 비차단):

- TodoItem 테스트의 `act()` 래핑 (현재 React 경고만 발생)
- `FilterBar` 단위 테스트 추가 (현재 App 통합으로만 검증)
- POST `dueDate: "not-a-date"` 케이스 — invalid_json vs validation_failed 정책 정렬
- PATCH wrong-type 케이스 (e.g. `{"completed":"yes"}`) 테스트 보강
- `useTodos` loading 상태 가시성 테스트

## superpowers 워크플로우 산출물

이 PR은 다음 skill 산출물을 포함합니다:

- `docs/superpowers/specs/2026-04-30-todo-app-design.md` (brainstorming skill)
- `docs/superpowers/plans/2026-04-30-todo-app-plan.md` (writing-plans skill)
- 24 commits — subagent-driven-development skill로 phase별 implementer + spec/quality reviewer 사이클 수행

🤖 Generated with [Claude Code](https://claude.com/claude-code)