### PR TITLE
[refactor] go-clean-arch-v2: viper → yaml.v3로 config 교체

### DIFF
--- a/project-layout/go-clean-arch-v2/cmd/main.go
+++ b/project-layout/go-clean-arch-v2/cmd/main.go
@@ -14,25 +14,21 @@ import (
 
 	"github.com/labstack/echo"
 
-	"github.com/spf13/viper"
-
 	"go.uber.org/fx"
 
 	_ "github.com/go-sql-driver/mysql"
 )
 
-func registerHooks(lifecycle fx.Lifecycle, e *echo.Echo, v *viper.Viper) {
+func registerHooks(lifecycle fx.Lifecycle, e *echo.Echo, cfg *config.Config) {
 	lifecycle.Append(
 		fx.Hook{
 			OnStart: func(context.Context) error {
 				fmt.Println("Starting server")
-				go e.Start(v.GetString("server.address"))
+				go e.Start(cfg.Server.Address)
 				return nil
 			},
 			OnStop: func(context.Context) error {
 				fmt.Println("Stopping server")
-				// logger.Print("Stopping admin server.")
-				// return logger.Sync()
 				return nil
 			},
 		},
@@ -46,12 +42,10 @@ func NewEcho() *echo.Echo {
 	return e
 }
 
-func ProvideBasicConfig() time.Duration {
-	duration := time.Duration(viper.GetInt("context.timeout")) * time.Second
-	return duration
+func ProvideBasicConfig(cfg *config.Config) time.Duration {
+	return time.Duration(cfg.Context.Timeout) * time.Second
 }
 
-// todo: 구동이후에 api 호출 주소가 등록이 안된 것 같음
 func main() {
 	app := fx.New(
 		fx.Provide(
@@ -77,19 +71,4 @@ func main() {
 	}
 
 	<-app.Done()
-
-	// 아래 버전은 잘 됨
-	// v := config.New()
-	// db, _ := database.New(v)
-	//
-	// e := NewEcho()
-	//
-	// authorRepo := author.NewMysqlAuthorRepository(db)
-	// ar := article.NewMysqlArticleRepository(db)
-	//
-	// timeoutContext := time.Duration(v.GetInt("context.timeout")) * time.Second
-	// au := article.NewArticleUsecase(ar, authorRepo, timeoutContext)
-	// article.NewArticleHandler(e, au)
-	//
-	// e.Start(v.GetString("server.address"))
 }

--- a/project-layout/go-clean-arch-v2/config.yaml
+++ b/project-layout/go-clean-arch-v2/config.yaml
@@ -1,0 +1,11 @@
+debug: true
+server:
+  address: ":8080"
+context:
+  timeout: 2
+database:
+  host: localhost
+  port: "3306"
+  user: user
+  pass: password
+  name: article

--- a/project-layout/go-clean-arch-v2/pkg/config/config.go
+++ b/project-layout/go-clean-arch-v2/pkg/config/config.go
@@ -1,26 +1,42 @@
 package config
 
 import (
-	"log"
+	"os"
 
-	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
 )
 
-const (
-	ConfigPath = "project-layout/go-clean-arch/config.json"
-)
+type Config struct {
+	Debug    bool     `yaml:"debug"`
+	Server   Server   `yaml:"server"`
+	Context  Context  `yaml:"context"`
+	Database Database `yaml:"database"`
+}
 
-func New() *viper.Viper {
-	v := viper.New()
-	v.SetConfigFile(ConfigPath)
-	err := v.ReadInConfig()
+type Server struct {
+	Address string `yaml:"address"`
+}
+
+type Context struct {
+	Timeout int `yaml:"timeout"` // seconds
+}
+
+type Database struct {
+	Host string `yaml:"host"`
+	Port string `yaml:"port"`
+	User string `yaml:"user"`
+	Pass string `yaml:"pass"`
+	Name string `yaml:"name"`
+}
+
+func New() (*Config, error) {
+	data, err := os.ReadFile("config.yaml")
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
-
-	if v.GetBool(`debug`) {
-		log.Println("Service RUN on DEBUG mode")
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, err
 	}
-
-	return v
+	return &cfg, nil
 }

--- a/project-layout/go-clean-arch-v2/pkg/database/db.go
+++ b/project-layout/go-clean-arch-v2/pkg/database/db.go
@@ -5,22 +5,17 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/spf13/viper"
+	"github.com/kenshin579/tutorials-go/project-layout/go-clean-arch-v2/pkg/config"
 )
 
-func New(v *viper.Viper) (*sql.DB, error) {
+func New(cfg *config.Config) (*sql.DB, error) {
 	fmt.Println("db config")
-	dbHost := v.GetString(`database.host`)
-	dbPort := v.GetString(`database.port`)
-	dbUser := v.GetString(`database.user`)
-	dbPass := v.GetString(`database.pass`)
-	dbName := v.GetString(`database.name`)
-	connection := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s", dbUser, dbPass, dbHost, dbPort, dbName)
+	d := cfg.Database
+	connection := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s", d.User, d.Pass, d.Host, d.Port, d.Name)
 	val := url.Values{}
 	val.Add("parseTime", "1")
 	val.Add("loc", "Asia/Seoul")
 	dsn := fmt.Sprintf("%s?%s", connection, val.Encode())
 
-	return sql.Open(`mysql`, dsn)
-
+	return sql.Open("mysql", dsn)
 }


### PR DESCRIPTION
## Summary

- `project-layout/go-clean-arch-v2/`의 `spf13/viper` 의존성을 `gopkg.in/yaml.v3` + 명시적 구조체 unmarshal로 교체
- `pkg/config`: `Config` 구조체와 `New() (*Config, error)`로 단순화 (panic 제거, fx가 error를 처리)
- `pkg/database`, `cmd/main`: 시그니처를 `*config.Config` 수신 형태로 변경
- `config.yaml` 신규 추가 (v1의 `config.json`을 YAML로 변환)
- 기존 dead code (수동 DI 주석) 정리

## 배경

블로그 글 'uber/fx로 의존성 주입 구현하기'의 주제는 **fx 의존성 주입**이지 config 라이브러리 비교가 아니라, viper의 부수 기능(자동 watch 등)이 입문 예제에 과하다고 판단. yaml.v3 단독 사용으로 단순화. 환경변수 override는 의도적으로 추가하지 않음 (YAGNI).

블로그 글 PR과 짝을 이룸: kenshin579/blog-v2.advenoh.pe.kr 의 `docs/go-fx-viper-to-yaml` 브랜치.

## Test plan

- [x] `go build ./...` 통과
- [x] `go vet ./...` 통과
- [x] `go test ./...` 통과 (article/author/middleware 패키지)
- [x] `grep -rn viper project-layout/go-clean-arch-v2 --include="*.go"` → 0건
- [x] go.mod에 yaml.v3 존재 (이미 indirect로 있던 의존성)

## 머지 순서

이 PR이 **블로그 글 PR보다 먼저 머지되어야 함**. 블로그 글이 master 브랜치의 코드를 참조하므로.