### PR TITLE
[fix] asynq 샘플 코드 컴파일 이슈 수정

### DIFF
--- a/scheduler/asynq/asynq_test.go
+++ b/scheduler/asynq/asynq_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/hibiken/asynq"
-	"github.com/kenshin579/tutorials-go/asynq/tasks"
+	"github.com/kenshin579/tutorials-go/scheduler/asynq/tasks"
 )
 
 const (

--- a/scheduler/asynq/periodic_test.go
+++ b/scheduler/asynq/periodic_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/go-redis/redis/v9"
 	"github.com/hibiken/asynq"
-	"github.com/kenshin579/tutorials-go/asynq/tasks"
+	"github.com/kenshin579/tutorials-go/scheduler/asynq/tasks"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -115,7 +115,8 @@ func Test_Periodic_Task_Manager(t *testing.T) {
 			schedulerInfoMap[i] = schedulerInfo{scheduler: scheduler, manager: manager}
 
 			if err := manager.Start(); err != nil {
-				t.Fatalf("Failed to start PeriodicTaskManager: %v", err)
+				t.Errorf("Failed to start PeriodicTaskManager: %v", err)
+				return
 			}
 
 			log.Printf("%d.running task manager", i)


### PR DESCRIPTION
## Summary
`scheduler/asynq` 디렉토리가 `scheduler/` 하위로 이동되면서 갱신되지 않은 import 경로로 인한 컴파일 이슈를 수정했습니다.

- `tasks` 패키지 import 경로 수정: `tutorials-go/asynq/tasks` → `tutorials-go/scheduler/asynq/tasks` (asynq_test.go, periodic_test.go)
- goroutine 내부의 `t.Fatalf` → `t.Errorf` + `return` 으로 변경 (`go vet` 경고 해소: "call to (*testing.T).Fatalf from a non-test goroutine")

## Test plan
- [x] `go build ./...` 통과
- [x] `go vet ./...` 통과
- [ ] `go test`는 Redis(localhost:6379) 필요 — 통합 테스트는 별도