### PR TITLE
[fix] 디렉토리 재구성으로 깨진 self-import 경로 일괄 수정

### DIFF
--- a/database/mysql/common/database/mysql.go
+++ b/database/mysql/common/database/mysql.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kenshin579/tutorials-go/go-mysql/config"
+	"github.com/kenshin579/tutorials-go/database/mysql/config"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"

--- a/database/mysql/config/config_test.go
+++ b/database/mysql/config/config_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/kenshin579/tutorials-go/go-mysql/config"
+	"github.com/kenshin579/tutorials-go/database/mysql/config"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/database/mysql/mysql_test.go
+++ b/database/mysql/mysql_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	db "github.com/kenshin579/tutorials-go/go-mysql/common/database"
-	"github.com/kenshin579/tutorials-go/go-mysql/config"
-	"github.com/kenshin579/tutorials-go/go-mysql/model"
+	db "github.com/kenshin579/tutorials-go/database/mysql/common/database"
+	"github.com/kenshin579/tutorials-go/database/mysql/config"
+	"github.com/kenshin579/tutorials-go/database/mysql/model"
 	"gorm.io/gorm"
 )
 

--- a/database/redis/blackboard/blackboard/route/http/blackboard_handler.go
+++ b/database/redis/blackboard/blackboard/route/http/blackboard_handler.go
@@ -3,7 +3,7 @@ package http
 import (
 	"net/http"
 
-	"github.com/kenshin579/tutorials-go/go-redis/blackboard/domain"
+	"github.com/kenshin579/tutorials-go/database/redis/blackboard/domain"
 	"github.com/labstack/echo"
 )
 

--- a/database/redis/blackboard/blackboard/store/redis/blackboard_http.go
+++ b/database/redis/blackboard/blackboard/store/redis/blackboard_http.go
@@ -1,8 +1,8 @@
 package redis
 
 import (
-	"github.com/kenshin579/tutorials-go/go-redis/blackboard/common/config"
-	"github.com/kenshin579/tutorials-go/go-redis/blackboard/domain"
+	"github.com/kenshin579/tutorials-go/database/redis/blackboard/common/config"
+	"github.com/kenshin579/tutorials-go/database/redis/blackboard/domain"
 )
 
 type redisBlackBoardStore struct {

--- a/database/redis/blackboard/blackboard/usecase/blackboard_ucase.go
+++ b/database/redis/blackboard/blackboard/usecase/blackboard_ucase.go
@@ -1,6 +1,6 @@
 package usecase
 
-import "github.com/kenshin579/tutorials-go/go-redis/blackboard/domain"
+import "github.com/kenshin579/tutorials-go/database/redis/blackboard/domain"
 
 type blackBoardUsecase struct {
 	blackBoardStore domain.BlackBoardStore

--- a/database/redis/blackboard/cmd/blackboard/main.go
+++ b/database/redis/blackboard/cmd/blackboard/main.go
@@ -3,15 +3,15 @@ package main
 import (
 	"log"
 
-	_blackBoardStore "github.com/kenshin579/tutorials-go/go-redis/blackboard/blackboard/store/redis"
+	_blackBoardStore "github.com/kenshin579/tutorials-go/database/redis/blackboard/blackboard/store/redis"
 
-	_blackBoardUsecase "github.com/kenshin579/tutorials-go/go-redis/blackboard/blackboard/usecase"
+	_blackBoardUsecase "github.com/kenshin579/tutorials-go/database/redis/blackboard/blackboard/usecase"
 
-	_blackBoardHandler "github.com/kenshin579/tutorials-go/go-redis/blackboard/blackboard/route/http"
+	_blackBoardHandler "github.com/kenshin579/tutorials-go/database/redis/blackboard/blackboard/route/http"
 
-	"github.com/kenshin579/tutorials-go/go-redis/blackboard/cmd/cli"
-	"github.com/kenshin579/tutorials-go/go-redis/blackboard/common/config"
-	"github.com/kenshin579/tutorials-go/go-redis/blackboard/common/router"
+	"github.com/kenshin579/tutorials-go/database/redis/blackboard/cmd/cli"
+	"github.com/kenshin579/tutorials-go/database/redis/blackboard/common/config"
+	"github.com/kenshin579/tutorials-go/database/redis/blackboard/common/router"
 )
 
 func main() {

--- a/database/redis/blackboard/common/config/config_test.go
+++ b/database/redis/blackboard/common/config/config_test.go
@@ -7,7 +7,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/kenshin579/tutorials-go/go-redis/blackboard/common/config"
+	"github.com/kenshin579/tutorials-go/database/redis/blackboard/common/config"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/database/redis/blackboard/common/router/router.go
+++ b/database/redis/blackboard/common/router/router.go
@@ -1,7 +1,7 @@
 package router
 
 import (
-	"github.com/kenshin579/tutorials-go/go-redis/blackboard/common/errors"
+	"github.com/kenshin579/tutorials-go/database/redis/blackboard/common/errors"
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"
 )

--- a/database/redis/cluster/cluster_test.go
+++ b/database/redis/cluster/cluster_test.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/kenshin579/tutorials-go/go-redis/model"
+	"github.com/kenshin579/tutorials-go/database/redis/model"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kenshin579/tutorials-go/go-redis/cluster/config"
+	"github.com/kenshin579/tutorials-go/database/redis/cluster/config"
 
 	"github.com/go-redis/redis/v8"
 )

--- a/golang/concurrency/waitgroup/account/account_test.go
+++ b/golang/concurrency/waitgroup/account/account_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/go-redsync/redsync/v4"
 	"github.com/go-redsync/redsync/v4/redis/goredis/v8"
 	"github.com/kenshin579/tutorials-go/common/util"
-	"github.com/kenshin579/tutorials-go/test/testcontainers"
+	testcontainers "github.com/kenshin579/tutorials-go/go-unit-test/testcontainers"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/golang/concurrency/waitgroup/counter/count_test.go
+++ b/golang/concurrency/waitgroup/counter/count_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/go-redsync/redsync/v4"
 	"github.com/go-redsync/redsync/v4/redis/goredis/v8"
 	"github.com/kenshin579/tutorials-go/common/util"
-	"github.com/kenshin579/tutorials-go/test/testcontainers"
+	testcontainers "github.com/kenshin579/tutorials-go/go-unit-test/testcontainers"
 	lock "github.com/square/mongo-lock"
 	"github.com/stretchr/testify/suite"
 	"go.mongodb.org/mongo-driver/mongo"

--- a/golang/data-structure/slices/slices_test.go
+++ b/golang/data-structure/slices/slices_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kenshin579/tutorials-go/go-data-structure/slices/model"
+	"github.com/kenshin579/tutorials-go/golang/data-structure/slices/model"
 )
 
 func Test_Delete_Item_Index_From_Slice(t *testing.T) {

--- a/golang/data-structure/sort/sort_test.go
+++ b/golang/data-structure/sort/sort_test.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/kenshin579/tutorials-go/go-data-structure/sort/model"
+	"github.com/kenshin579/tutorials-go/golang/data-structure/sort/model"
 	"golang.org/x/exp/slices"
 )
 

--- a/golang/errors/custom/error_test.go
+++ b/golang/errors/custom/error_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/kenshin579/tutorials-go/go-errors/custom/model"
+	"github.com/kenshin579/tutorials-go/golang/errors/custom/model"
 )
 
 func ExampleCreating_Error_New() {

--- a/golang/functional/functional_test.go
+++ b/golang/functional/functional_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kenshin579/tutorials-go/go-functional/util"
+	"github.com/kenshin579/tutorials-go/golang/functional/util"
 )
 
 func setup() []string {

--- a/golang/json/json_test.go
+++ b/golang/json/json_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/kenshin579/tutorials-go/go-json/model"
+	"github.com/kenshin579/tutorials-go/golang/json/model"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/golang/profiling/profiling-examples/main.go
+++ b/golang/profiling/profiling-examples/main.go
@@ -10,11 +10,11 @@ import (
 	"syscall"
 
 	"github.com/google/gops/agent"
-	"github.com/kenshin579/tutorials-go/go-profiling/profiling-examples/pkg/block"
-	"github.com/kenshin579/tutorials-go/go-profiling/profiling-examples/pkg/cpu"
-	"github.com/kenshin579/tutorials-go/go-profiling/profiling-examples/pkg/memory"
-	"github.com/kenshin579/tutorials-go/go-profiling/profiling-examples/pkg/mutex"
-	"github.com/kenshin579/tutorials-go/go-profiling/profiling-examples/pkg/threadcreate"
+	"github.com/kenshin579/tutorials-go/golang/profiling/profiling-examples/pkg/block"
+	"github.com/kenshin579/tutorials-go/golang/profiling/profiling-examples/pkg/cpu"
+	"github.com/kenshin579/tutorials-go/golang/profiling/profiling-examples/pkg/memory"
+	"github.com/kenshin579/tutorials-go/golang/profiling/profiling-examples/pkg/mutex"
+	"github.com/kenshin579/tutorials-go/golang/profiling/profiling-examples/pkg/threadcreate"
 )
 
 // 종합 프로파일링 예제 - CPU, 메모리, 블로킹, 뮤텍스, 스레드 생성 프로파일을 동시에 수집할 수 있다.

--- a/golang/runtime/runtime_test.go
+++ b/golang/runtime/runtime_test.go
@@ -19,7 +19,7 @@ func bar() string {
 func Test_실행중인_함수이름_가져오기(t *testing.T) {
 	result := bar()
 	assert.Equal(t,
-		"github.com/kenshin579/tutorials-go/go-runtime.Test_실행중인_함수이름_가져오기",
+		"github.com/kenshin579/tutorials-go/golang/runtime.Test_실행중인_함수이름_가져오기",
 		result)
 }
 

--- a/golang/third-party/caching/go-cache-redis/cache_redis_test.go
+++ b/golang/third-party/caching/go-cache-redis/cache_redis_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/go-redis/redis/v8"
-	"github.com/kenshin579/tutorials-go/test/inmemory"
+	"github.com/kenshin579/tutorials-go/database/miniredis/inmemory"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/go-redis/cache/v8"

--- a/golang/third-party/echo-web-framework/article/handler/article_handler.go
+++ b/golang/third-party/echo-web-framework/article/handler/article_handler.go
@@ -3,8 +3,8 @@ package handler
 import (
 	"net/http"
 
-	"github.com/kenshin579/tutorials-go/third-party/go-echo-web-framework/article/model"
-	"github.com/kenshin579/tutorials-go/third-party/go-echo-web-framework/article/utils"
+	"github.com/kenshin579/tutorials-go/golang/third-party/echo-web-framework/article/model"
+	"github.com/kenshin579/tutorials-go/golang/third-party/echo-web-framework/article/utils"
 	"github.com/labstack/echo"
 )
 

--- a/golang/third-party/echo-web-framework/article/main.go
+++ b/golang/third-party/echo-web-framework/article/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"github.com/kenshin579/tutorials-go/third-party/go-echo-web-framework/article/handler"
-	"github.com/kenshin579/tutorials-go/third-party/go-echo-web-framework/article/router"
-	"github.com/kenshin579/tutorials-go/third-party/go-echo-web-framework/article/store"
-	"github.com/kenshin579/tutorials-go/third-party/go-echo-web-framework/article/usecase"
+	"github.com/kenshin579/tutorials-go/golang/third-party/echo-web-framework/article/handler"
+	"github.com/kenshin579/tutorials-go/golang/third-party/echo-web-framework/article/router"
+	"github.com/kenshin579/tutorials-go/golang/third-party/echo-web-framework/article/store"
+	"github.com/kenshin579/tutorials-go/golang/third-party/echo-web-framework/article/usecase"
 )
 
 func main() {

--- a/golang/third-party/echo-web-framework/article/store/article_store.go
+++ b/golang/third-party/echo-web-framework/article/store/article_store.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	"github.com/google/uuid"
-	"github.com/kenshin579/tutorials-go/go-echo-web-framework/article/model"
+	"github.com/kenshin579/tutorials-go/golang/third-party/echo-web-framework/article/model"
 )
 
 var (

--- a/golang/third-party/echo-web-framework/article/usecase/article_usecase.go
+++ b/golang/third-party/echo-web-framework/article/usecase/article_usecase.go
@@ -1,7 +1,7 @@
 package usecase
 
 import (
-	"github.com/kenshin579/tutorials-go/third-party/go-echo-web-framework/article/model"
+	"github.com/kenshin579/tutorials-go/golang/third-party/echo-web-framework/article/model"
 	"github.com/labstack/gommon/log"
 )
 

--- a/golang/third-party/flatbson/flatbson_test.go
+++ b/golang/third-party/flatbson/flatbson_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kenshin579/tutorials-go/go-mongo/adapter/mongodb"
+	"github.com/kenshin579/tutorials-go/database/mongo/adapter/mongodb"
 
 	"github.com/chidiwilliams/flatbson"
 
@@ -18,9 +18,9 @@ import (
 
 	"go.mongodb.org/mongo-driver/bson"
 
-	"github.com/kenshin579/tutorials-go/go-flatbson/model"
+	"github.com/kenshin579/tutorials-go/golang/third-party/flatbson/model"
 
-	"github.com/kenshin579/tutorials-go/go-mongo/config"
+	"github.com/kenshin579/tutorials-go/database/mongo/config"
 
 	"go.mongodb.org/mongo-driver/mongo"
 )

--- a/golang/third-party/funk/funk_test.go
+++ b/golang/third-party/funk/funk_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/kenshin579/tutorials-go/go-funk/domain"
+	"github.com/kenshin579/tutorials-go/golang/third-party/funk/domain"
 	"github.com/stretchr/testify/assert"
 	"github.com/thoas/go-funk"
 )

--- a/golang/third-party/funk/model/model.go
+++ b/golang/third-party/funk/model/model.go
@@ -1,7 +1,7 @@
 package model
 
 import (
-	"github.com/kenshin579/tutorials-go/go-funk/domain"
+	"github.com/kenshin579/tutorials-go/golang/third-party/funk/domain"
 )
 
 type ModelNodes []domain.Node

--- a/golang/third-party/fx/ex3/internal/handler/module.go
+++ b/golang/third-party/fx/ex3/internal/handler/module.go
@@ -1,7 +1,7 @@
 package handler
 
 import (
-	"github.com/kenshin579/tutorials-go/go-fx/ex3/internal/handler/hello"
+	"github.com/kenshin579/tutorials-go/golang/third-party/fx/ex3/internal/handler/hello"
 	"go.uber.org/fx"
 )
 

--- a/golang/third-party/fx/ex3/internal/routes/register.go
+++ b/golang/third-party/fx/ex3/internal/routes/register.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/kenshin579/tutorials-go/go-fx/ex3/internal/handler/hello"
+	"github.com/kenshin579/tutorials-go/golang/third-party/fx/ex3/internal/handler/hello"
 
 	"go.uber.org/fx"
 	"go.uber.org/zap"

--- a/golang/third-party/fx/ex3/main.go
+++ b/golang/third-party/fx/ex3/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"github.com/kenshin579/tutorials-go/go-fx/ex3/internal/handler"
-	"github.com/kenshin579/tutorials-go/go-fx/ex3/internal/loggerfx"
-	"github.com/kenshin579/tutorials-go/go-fx/ex3/internal/routes"
+	"github.com/kenshin579/tutorials-go/golang/third-party/fx/ex3/internal/handler"
+	"github.com/kenshin579/tutorials-go/golang/third-party/fx/ex3/internal/loggerfx"
+	"github.com/kenshin579/tutorials-go/golang/third-party/fx/ex3/internal/routes"
 	"go.uber.org/fx"
 )
 

--- a/golang/third-party/fx/sumit_agarwal/v1/main.go
+++ b/golang/third-party/fx/sumit_agarwal/v1/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"net/http"
 
-	"github.com/kenshin579/tutorials-go/go-fx/sumit_agarwal/v1/server"
+	"github.com/kenshin579/tutorials-go/golang/third-party/fx/sumit_agarwal/v1/server"
 )
 
 func main() {

--- a/golang/third-party/fx/sumit_agarwal/v2/main.go
+++ b/golang/third-party/fx/sumit_agarwal/v2/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/kenshin579/tutorials-go/go-fx/sumit_agarwal/v2/server"
+	"github.com/kenshin579/tutorials-go/golang/third-party/fx/sumit_agarwal/v2/server"
 	"go.uber.org/fx"
 )
 

--- a/golang/third-party/fx/sumit_agarwal/v3/main.go
+++ b/golang/third-party/fx/sumit_agarwal/v3/main.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/kenshin579/tutorials-go/go-fx/sumit_agarwal/v3/loggerfx"
-	"github.com/kenshin579/tutorials-go/go-fx/sumit_agarwal/v3/server"
+	"github.com/kenshin579/tutorials-go/golang/third-party/fx/sumit_agarwal/v3/loggerfx"
+	"github.com/kenshin579/tutorials-go/golang/third-party/fx/sumit_agarwal/v3/server"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
 )

--- a/golang/third-party/fx/sumit_agarwal/v4/main.go
+++ b/golang/third-party/fx/sumit_agarwal/v4/main.go
@@ -6,10 +6,10 @@ import (
 	"net/http"
 	"net/rpc"
 
-	httpServer "github.com/kenshin579/tutorials-go/go-fx/sumit_agarwal/v4/http"
-	rpcServer "github.com/kenshin579/tutorials-go/go-fx/sumit_agarwal/v4/rpc"
+	httpServer "github.com/kenshin579/tutorials-go/golang/third-party/fx/sumit_agarwal/v4/http"
+	rpcServer "github.com/kenshin579/tutorials-go/golang/third-party/fx/sumit_agarwal/v4/rpc"
 
-	"github.com/kenshin579/tutorials-go/go-fx/sumit_agarwal/v4/loggerfx"
+	"github.com/kenshin579/tutorials-go/golang/third-party/fx/sumit_agarwal/v4/loggerfx"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
 )

--- a/golang/third-party/fx/sumit_agarwal/v5/main.go
+++ b/golang/third-party/fx/sumit_agarwal/v5/main.go
@@ -5,10 +5,10 @@ import (
 	"net"
 	"net/http"
 
-	httpServer "github.com/kenshin579/tutorials-go/go-fx/sumit_agarwal/v5/http"
-	"github.com/kenshin579/tutorials-go/go-fx/sumit_agarwal/v5/loggerfx"
-	pb "github.com/kenshin579/tutorials-go/go-fx/sumit_agarwal/v5/proto"
-	rpcServer "github.com/kenshin579/tutorials-go/go-fx/sumit_agarwal/v5/rpc"
+	httpServer "github.com/kenshin579/tutorials-go/golang/third-party/fx/sumit_agarwal/v5/http"
+	"github.com/kenshin579/tutorials-go/golang/third-party/fx/sumit_agarwal/v5/loggerfx"
+	pb "github.com/kenshin579/tutorials-go/golang/third-party/fx/sumit_agarwal/v5/proto"
+	rpcServer "github.com/kenshin579/tutorials-go/golang/third-party/fx/sumit_agarwal/v5/rpc"
 
 	"go.uber.org/fx"
 	"go.uber.org/zap"

--- a/golang/third-party/fx/sumit_agarwal/v5/rpc/rpc.go
+++ b/golang/third-party/fx/sumit_agarwal/v5/rpc/rpc.go
@@ -3,7 +3,7 @@ package rpc
 import (
 	"context"
 
-	pb "github.com/kenshin579/tutorials-go/go-fx/sumit_agarwal/v5/proto"
+	pb "github.com/kenshin579/tutorials-go/golang/third-party/fx/sumit_agarwal/v5/proto"
 )
 
 type Handler = pb.UsersServer

--- a/golang/third-party/grpc/helloworld/client/client.go
+++ b/golang/third-party/grpc/helloworld/client/client.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/kenshin579/tutorials-go/go-grpc/helloworld/chat"
+	"github.com/kenshin579/tutorials-go/golang/third-party/grpc/helloworld/chat"
 
 	"google.golang.org/grpc"
 )

--- a/golang/third-party/grpc/helloworld/server/chat.go
+++ b/golang/third-party/grpc/helloworld/server/chat.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 
-	"github.com/kenshin579/tutorials-go/go-grpc/helloworld/chat"
+	"github.com/kenshin579/tutorials-go/golang/third-party/grpc/helloworld/chat"
 	"golang.org/x/net/context"
 )
 

--- a/golang/third-party/grpc/helloworld/server/server.go
+++ b/golang/third-party/grpc/helloworld/server/server.go
@@ -6,7 +6,7 @@ import (
 	"net"
 
 	_ "github.com/jnewmano/grpc-json-proxy/codec"
-	"github.com/kenshin579/tutorials-go/go-grpc/helloworld/chat"
+	"github.com/kenshin579/tutorials-go/golang/third-party/grpc/helloworld/chat"
 	"google.golang.org/grpc"
 )
 

--- a/golang/third-party/grpc/route_guide/client/client.go
+++ b/golang/third-party/grpc/route_guide/client/client.go
@@ -8,7 +8,7 @@ import (
 	"math/rand"
 	"time"
 
-	pb "github.com/kenshin579/tutorials-go/go-grpc/route_guide/routeguide"
+	pb "github.com/kenshin579/tutorials-go/golang/third-party/grpc/route_guide/routeguide"
 	"google.golang.org/grpc"
 )
 

--- a/golang/third-party/grpc/route_guide/server/server.go
+++ b/golang/third-party/grpc/route_guide/server/server.go
@@ -18,7 +18,7 @@ import (
 	"github.com/golang/protobuf/proto"
 
 	_ "github.com/jnewmano/grpc-json-proxy/codec"
-	pb "github.com/kenshin579/tutorials-go/go-grpc/route_guide/routeguide"
+	pb "github.com/kenshin579/tutorials-go/golang/third-party/grpc/route_guide/routeguide"
 )
 
 var (

--- a/golang/third-party/validation/article/handler/article_handler.go
+++ b/golang/third-party/validation/article/handler/article_handler.go
@@ -3,11 +3,11 @@ package handler
 import (
 	"net/http"
 
-	"github.com/kenshin579/tutorials-go/go-validation/article/exception"
+	"github.com/kenshin579/tutorials-go/golang/third-party/validation/article/exception"
 
-	"github.com/kenshin579/tutorials-go/go-validation/article/utils"
+	"github.com/kenshin579/tutorials-go/golang/third-party/validation/article/utils"
 
-	"github.com/kenshin579/tutorials-go/go-validation/article/model"
+	"github.com/kenshin579/tutorials-go/golang/third-party/validation/article/model"
 	"github.com/labstack/echo"
 )
 

--- a/golang/third-party/validation/article/handler/article_handler_test.go
+++ b/golang/third-party/validation/article/handler/article_handler_test.go
@@ -9,17 +9,17 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kenshin579/tutorials-go/go-validation/article/exception"
+	"github.com/kenshin579/tutorials-go/golang/third-party/validation/article/exception"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kenshin579/tutorials-go/go-validation/article/store"
+	"github.com/kenshin579/tutorials-go/golang/third-party/validation/article/store"
 
-	"github.com/kenshin579/tutorials-go/go-validation/article/router"
-	"github.com/kenshin579/tutorials-go/go-validation/article/usecase"
+	"github.com/kenshin579/tutorials-go/golang/third-party/validation/article/router"
+	"github.com/kenshin579/tutorials-go/golang/third-party/validation/article/usecase"
 
-	"github.com/kenshin579/tutorials-go/go-validation/article/model"
+	"github.com/kenshin579/tutorials-go/golang/third-party/validation/article/model"
 	"github.com/labstack/echo"
 )
 

--- a/golang/third-party/validation/article/main.go
+++ b/golang/third-party/validation/article/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"github.com/kenshin579/tutorials-go/go-validation/article/handler"
-	"github.com/kenshin579/tutorials-go/go-validation/article/router"
-	"github.com/kenshin579/tutorials-go/go-validation/article/store"
-	"github.com/kenshin579/tutorials-go/go-validation/article/usecase"
+	"github.com/kenshin579/tutorials-go/golang/third-party/validation/article/handler"
+	"github.com/kenshin579/tutorials-go/golang/third-party/validation/article/router"
+	"github.com/kenshin579/tutorials-go/golang/third-party/validation/article/store"
+	"github.com/kenshin579/tutorials-go/golang/third-party/validation/article/usecase"
 )
 
 func main() {

--- a/golang/third-party/validation/article/router/error_handler.go
+++ b/golang/third-party/validation/article/router/error_handler.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/kenshin579/tutorials-go/go-validation/article/exception"
+	"github.com/kenshin579/tutorials-go/golang/third-party/validation/article/exception"
 
 	"github.com/go-playground/validator/v10"
 

--- a/golang/third-party/validation/article/router/validator.go
+++ b/golang/third-party/validation/article/router/validator.go
@@ -1,8 +1,8 @@
 package router
 
 import (
-	"github.com/kenshin579/tutorials-go/go-validation/article/model"
-	"github.com/kenshin579/tutorials-go/go-validation/article/utils"
+	"github.com/kenshin579/tutorials-go/golang/third-party/validation/article/model"
+	"github.com/kenshin579/tutorials-go/golang/third-party/validation/article/utils"
 
 	"github.com/go-playground/validator/v10"
 )

--- a/golang/third-party/validation/article/router/validator_test.go
+++ b/golang/third-party/validation/article/router/validator_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kenshin579/tutorials-go/go-validation/article/model"
+	"github.com/kenshin579/tutorials-go/golang/third-party/validation/article/model"
 )
 
 func TestValidatePostStatus(t *testing.T) {

--- a/golang/third-party/validation/article/store/article_store.go
+++ b/golang/third-party/validation/article/store/article_store.go
@@ -2,8 +2,8 @@ package store
 
 import (
 	"github.com/google/uuid"
-	"github.com/kenshin579/tutorials-go/go-validation/article/exception"
-	"github.com/kenshin579/tutorials-go/go-validation/article/model"
+	"github.com/kenshin579/tutorials-go/golang/third-party/validation/article/exception"
+	"github.com/kenshin579/tutorials-go/golang/third-party/validation/article/model"
 )
 
 type ArticleStore struct {

--- a/golang/third-party/validation/article/usecase/article_usecase.go
+++ b/golang/third-party/validation/article/usecase/article_usecase.go
@@ -1,7 +1,7 @@
 package usecase
 
 import (
-	"github.com/kenshin579/tutorials-go/go-validation/article/model"
+	"github.com/kenshin579/tutorials-go/golang/third-party/validation/article/model"
 	"github.com/labstack/gommon/log"
 )
 

--- a/golang/third-party/validation/article/utils/util.go
+++ b/golang/third-party/validation/article/utils/util.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kenshin579/tutorials-go/go-validation/article/model"
+	"github.com/kenshin579/tutorials-go/golang/third-party/validation/article/model"
 )
 
 func Index(list interface{}, t interface{}) int {

--- a/golang/third-party/validation/go-validator/validator_test.go
+++ b/golang/third-party/validation/go-validator/validator_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kenshin579/tutorials-go/third-party/go-validation/go-validator/model"
+	"github.com/kenshin579/tutorials-go/golang/third-party/validation/go-validator/model"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/go-playground/locales/en"

--- a/golang/third-party/yaml/util/config/config.go
+++ b/golang/third-party/yaml/util/config/config.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/kenshin579/tutorials-go/go-yaml/model"
+	"github.com/kenshin579/tutorials-go/golang/third-party/yaml/model"
 
 	"gopkg.in/yaml.v3"
 )

--- a/golang/workspace-oldway/service/main.go
+++ b/golang/workspace-oldway/service/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/kenshin579/tutorials-go/go-workspace-oldway/adder"
+	"github.com/kenshin579/tutorials-go/golang/workspace-oldway/adder"
 )
 
 func main() {

--- a/golang/workspace/service/main.go
+++ b/golang/workspace/service/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/kenshin579/tutorials-go/go-workspace/adder"
+	"github.com/kenshin579/tutorials-go/golang/workspace/adder"
 )
 
 func main() {

--- a/scheduler/go-schedule/robfig/cron_test.go
+++ b/scheduler/go-schedule/robfig/cron_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kenshin579/tutorials-go/go-schedule/job"
+	"github.com/kenshin579/tutorials-go/scheduler/go-schedule/job"
 	"github.com/robfig/cron/v3"
 )
 

--- a/scheduler/go-schedule/scheduler/cmd/scheduler/main.go
+++ b/scheduler/go-schedule/scheduler/cmd/scheduler/main.go
@@ -3,15 +3,15 @@ package main
 import (
 	"log"
 
-	"github.com/kenshin579/tutorials-go/go-schedule/scheduler/common/cronner"
+	"github.com/kenshin579/tutorials-go/scheduler/go-schedule/scheduler/common/cronner"
 
-	"github.com/kenshin579/tutorials-go/go-schedule/scheduler/cmd/cli"
-	"github.com/kenshin579/tutorials-go/go-schedule/scheduler/common/config"
-	"github.com/kenshin579/tutorials-go/go-schedule/scheduler/common/router"
+	"github.com/kenshin579/tutorials-go/scheduler/go-schedule/scheduler/cmd/cli"
+	"github.com/kenshin579/tutorials-go/scheduler/go-schedule/scheduler/common/config"
+	"github.com/kenshin579/tutorials-go/scheduler/go-schedule/scheduler/common/router"
 
-	_scheduleHandler "github.com/kenshin579/tutorials-go/go-schedule/scheduler/schedule/route/http"
-	_scheduleStore "github.com/kenshin579/tutorials-go/go-schedule/scheduler/schedule/store/local"
-	_scheduleUsecase "github.com/kenshin579/tutorials-go/go-schedule/scheduler/schedule/usecase"
+	_scheduleHandler "github.com/kenshin579/tutorials-go/scheduler/go-schedule/scheduler/schedule/route/http"
+	_scheduleStore "github.com/kenshin579/tutorials-go/scheduler/go-schedule/scheduler/schedule/store/local"
+	_scheduleUsecase "github.com/kenshin579/tutorials-go/scheduler/go-schedule/scheduler/schedule/usecase"
 )
 
 func main() {

--- a/scheduler/go-schedule/scheduler/common/config/config.go
+++ b/scheduler/go-schedule/scheduler/common/config/config.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/kenshin579/tutorials-go/go-schedule/scheduler/domain"
+	"github.com/kenshin579/tutorials-go/scheduler/go-schedule/scheduler/domain"
 
 	"gopkg.in/yaml.v3"
 )

--- a/scheduler/go-schedule/scheduler/common/config/config_test.go
+++ b/scheduler/go-schedule/scheduler/common/config/config_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kenshin579/tutorials-go/go-schedule/scheduler/common/config"
+	"github.com/kenshin579/tutorials-go/scheduler/go-schedule/scheduler/common/config"
 )
 
 func init() {

--- a/scheduler/go-schedule/scheduler/common/router/router.go
+++ b/scheduler/go-schedule/scheduler/common/router/router.go
@@ -1,7 +1,7 @@
 package router
 
 import (
-	"github.com/kenshin579/tutorials-go/go-schedule/scheduler/common/errors"
+	"github.com/kenshin579/tutorials-go/scheduler/go-schedule/scheduler/common/errors"
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"
 )

--- a/scheduler/go-schedule/scheduler/domain/job/move_file.go
+++ b/scheduler/go-schedule/scheduler/domain/job/move_file.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/kenshin579/tutorials-go/go-schedule/scheduler/common/utils"
+	"github.com/kenshin579/tutorials-go/scheduler/go-schedule/scheduler/common/utils"
 
 	"github.com/labstack/gommon/log"
 )

--- a/scheduler/go-schedule/scheduler/domain/mocks/ScheduleStore.go
+++ b/scheduler/go-schedule/scheduler/domain/mocks/ScheduleStore.go
@@ -3,7 +3,7 @@
 package mocks
 
 import (
-	domain "github.com/kenshin579/tutorials-go/go-schedule/scheduler/domain"
+	domain "github.com/kenshin579/tutorials-go/scheduler/go-schedule/scheduler/domain"
 	mock "github.com/stretchr/testify/mock"
 )
 

--- a/scheduler/go-schedule/scheduler/domain/mocks/ScheduleUsecase.go
+++ b/scheduler/go-schedule/scheduler/domain/mocks/ScheduleUsecase.go
@@ -3,7 +3,7 @@
 package mocks
 
 import (
-	domain "github.com/kenshin579/tutorials-go/go-schedule/scheduler/domain"
+	domain "github.com/kenshin579/tutorials-go/scheduler/go-schedule/scheduler/domain"
 	mock "github.com/stretchr/testify/mock"
 )
 

--- a/scheduler/go-schedule/scheduler/schedule/route/http/schedule_handler.go
+++ b/scheduler/go-schedule/scheduler/schedule/route/http/schedule_handler.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/labstack/gommon/log"
 
-	"github.com/kenshin579/tutorials-go/go-schedule/scheduler/common/errors"
+	"github.com/kenshin579/tutorials-go/scheduler/go-schedule/scheduler/common/errors"
 
-	"github.com/kenshin579/tutorials-go/go-schedule/scheduler/domain"
+	"github.com/kenshin579/tutorials-go/scheduler/go-schedule/scheduler/domain"
 	"github.com/labstack/echo"
 )
 

--- a/scheduler/go-schedule/scheduler/schedule/store/local/schedule_local.go
+++ b/scheduler/go-schedule/scheduler/schedule/store/local/schedule_local.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 
-	"github.com/kenshin579/tutorials-go/go-schedule/scheduler/common/cronner"
-	scheduleError "github.com/kenshin579/tutorials-go/go-schedule/scheduler/common/errors"
-	"github.com/kenshin579/tutorials-go/go-schedule/scheduler/domain"
-	"github.com/kenshin579/tutorials-go/go-schedule/scheduler/domain/job"
+	"github.com/kenshin579/tutorials-go/scheduler/go-schedule/scheduler/common/cronner"
+	scheduleError "github.com/kenshin579/tutorials-go/scheduler/go-schedule/scheduler/common/errors"
+	"github.com/kenshin579/tutorials-go/scheduler/go-schedule/scheduler/domain"
+	"github.com/kenshin579/tutorials-go/scheduler/go-schedule/scheduler/domain/job"
 	"github.com/labstack/gommon/log"
 )
 

--- a/scheduler/go-schedule/scheduler/schedule/store/local/schedule_local_test.go
+++ b/scheduler/go-schedule/scheduler/schedule/store/local/schedule_local_test.go
@@ -3,9 +3,9 @@ package local
 import (
 	"testing"
 
-	"github.com/kenshin579/tutorials-go/go-schedule/scheduler/common/cronner"
-	"github.com/kenshin579/tutorials-go/go-schedule/scheduler/domain"
-	"github.com/kenshin579/tutorials-go/go-schedule/scheduler/domain/job"
+	"github.com/kenshin579/tutorials-go/scheduler/go-schedule/scheduler/common/cronner"
+	"github.com/kenshin579/tutorials-go/scheduler/go-schedule/scheduler/domain"
+	"github.com/kenshin579/tutorials-go/scheduler/go-schedule/scheduler/domain/job"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/scheduler/go-schedule/scheduler/schedule/usecase/schedule_ucase.go
+++ b/scheduler/go-schedule/scheduler/schedule/usecase/schedule_ucase.go
@@ -1,8 +1,8 @@
 package usecase
 
 import (
-	"github.com/kenshin579/tutorials-go/go-schedule/scheduler/common/config"
-	"github.com/kenshin579/tutorials-go/go-schedule/scheduler/domain"
+	"github.com/kenshin579/tutorials-go/scheduler/go-schedule/scheduler/common/config"
+	"github.com/kenshin579/tutorials-go/scheduler/go-schedule/scheduler/domain"
 	"github.com/labstack/gommon/log"
 )
 

--- a/scheduler/go-schedule/scheduler/schedule/usecase/schedule_ucase_test.go
+++ b/scheduler/go-schedule/scheduler/schedule/usecase/schedule_ucase_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/labstack/gommon/log"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kenshin579/tutorials-go/go-schedule/scheduler/common/config"
-	"github.com/kenshin579/tutorials-go/go-schedule/scheduler/common/cronner"
+	"github.com/kenshin579/tutorials-go/scheduler/go-schedule/scheduler/common/config"
+	"github.com/kenshin579/tutorials-go/scheduler/go-schedule/scheduler/common/cronner"
 
-	"github.com/kenshin579/tutorials-go/go-schedule/scheduler/domain"
-	"github.com/kenshin579/tutorials-go/go-schedule/scheduler/schedule/store/local"
+	"github.com/kenshin579/tutorials-go/scheduler/go-schedule/scheduler/domain"
+	"github.com/kenshin579/tutorials-go/scheduler/go-schedule/scheduler/schedule/store/local"
 )
 
 var (


### PR DESCRIPTION
## Summary
디렉토리 구조가 재구성(예: `go-fx/` → `golang/third-party/fx/`)되면서 갱신되지 않은 self-import 경로로 인해 저장소 곳곳에서 컴파일 오류가 발생하고 있었습니다. 끊긴 import 경로 약 70건(67개 파일)을 실제 디렉토리 위치로 일괄 수정했습니다.

### 주요 매핑
| 기존 (끊김) | 수정 |
|---|---|
| `go-fx/*`, `go-grpc/*`, `go-funk/*`, `go-yaml/*`, `go-validation/*`, `go-echo-web-framework/*` | `golang/third-party/*` |
| `go-mysql/*`, `go-redis/*`, `go-mongo/*` | `database/*` |
| `go-schedule/*` | `scheduler/go-schedule/*` |
| `go-errors/*`, `go-json/*`, `go-functional/*`, `go-profiling/*`, `go-data-structure/*`, `go-workspace*/*` | `golang/*` |
| `test/testcontainers` | `go-unit-test/testcontainers` (+ import alias) |
| `test/inmemory` | `database/miniredis/inmemory` |

순수 import 경로 치환이며 로직 변경은 없습니다. (runtime 테스트의 stale 패키지명 문자열 리터럴 1건 포함)

## Test plan
- [x] `go build ./...` — reorg 관련 import 오류 전부 해소
- [ ] 잔여 컴파일 오류 5건은 **reorg와 무관한 기존 버그**로 별도 PR 예정:
  - `golang/data-structure/sort` (slices.SortFunc 시그니처 변경)
  - `golang/third-party/protobuf` (func main 누락)
  - `golang/goroutine/.../separate_channel` (undefined: Result)
  - `go-unit-test/mockery/message` (mock 인터페이스 미구현)
  - `database/mongo/test/memongo` (memongo.Options API 변경)