### PR TITLE
[fix] 기존 컴파일 오류 5건 수정 (sort/protobuf/goroutine/mockery/memongo)

### DIFF
--- a/database/mongo/test/memongo/memongo.go
+++ b/database/mongo/test/memongo/memongo.go
@@ -11,8 +11,7 @@ import (
 
 func NewMemongoDB() (*mongo.Database, error) {
 	opts := &memongo.Options{
-		MongoVersion:     "4.2.1",
-		ShouldUseReplica: false,
+		MongoVersion: "4.2.1",
 	}
 
 	if runtime.GOARCH == "arm64" {

--- a/go-unit-test/mockery/message/main_test.go
+++ b/go-unit-test/mockery/message/main_test.go
@@ -12,16 +12,15 @@ type smsServiceMock struct {
 }
 
 // Our mocked smsService method
-func (m *smsServiceMock) SendChargeNotification(value int) bool {
+func (m *smsServiceMock) SendChargeNotification(value int) error {
 	fmt.Println("Mocked charge notification function")
 	fmt.Printf("Value passed in: %d\n", value)
 	// this records that the method was called and passes in the value
 	// it was called with
 	args := m.Called(value)
 	// it then returns whatever we tell it to return
-	// in this case true to simulate an SMS Service Notification
-	// sent out
-	return args.Bool(0)
+	// in this case nil to simulate a successfully sent SMS Service Notification
+	return args.Error(0)
 }
 
 // we need to satisfy our MessageService interface
@@ -39,7 +38,7 @@ func TestChargeCustomer(t *testing.T) {
 	// we then define what should be returned from SendChargeNotification
 	// when we pass in the value 100 to it. In this case, we want to return
 	// true as it was successful in sending a notification
-	smsService.On("SendChargeNotification", 100).Return(true)
+	smsService.On("SendChargeNotification", 100).Return(nil)
 
 	// next we want to define the service we wish to test
 	myService := MyService{smsService}

--- a/golang/data-structure/sort/sort_test.go
+++ b/golang/data-structure/sort/sort_test.go
@@ -1,6 +1,7 @@
 package sort
 
 import (
+	"cmp"
 	"fmt"
 	"sort"
 	"strings"
@@ -68,8 +69,8 @@ func Example_slicesSortFunc() {
 		{"Bob", 25},
 	}
 
-	slices.SortFunc(employees, func(x, y model.Employee) bool {
-		return x.Age < y.Age
+	slices.SortFunc(employees, func(x, y model.Employee) int {
+		return cmp.Compare(x.Age, y.Age)
 	})
 	fmt.Println(employees)
 

--- a/golang/goroutine/error_handling/separate_channel/separate_channel_test.go
+++ b/golang/goroutine/error_handling/separate_channel/separate_channel_test.go
@@ -6,6 +6,12 @@ import (
 	"time"
 )
 
+// Result는 에러 이름과 발생 횟수를 담는 결과 타입이다.
+type Result struct {
+	ErrorName          string
+	NumberOfOccurances int64
+}
+
 func Test_Separate_Channel_Both_Result_And_Error(t *testing.T) {
 	fmt.Println("Using separate channels for error and result")
 

--- a/golang/third-party/protobuf/main.go
+++ b/golang/third-party/protobuf/main.go
@@ -1,0 +1,5 @@
+package main
+
+// 이 패키지는 protobuf 직렬화 예제를 테스트(protobuf_test.go)로 다룬다.
+// package main 으로 빌드되려면 main 함수가 필요하므로 빈 엔트리포인트를 둔다.
+func main() {}


### PR DESCRIPTION
## Summary
import 경로 reorg(#711)와 무관하게 남아 있던 기존 컴파일 오류 5건을 수정했습니다. 의존성/표준 라이브러리 API 변화 등으로 인한 빌드 실패였습니다.

| 위치 | 원인 | 수정 |
|---|---|---|
| `golang/data-structure/sort` | `slices.SortFunc` 비교 함수가 `int` 반환 요구 (Go 1.21+) | `func(x, y) int { return cmp.Compare(...) }` 로 변경 |
| `golang/third-party/protobuf` | `package main`에 `func main` 없음 | 빈 `func main()` 추가 |
| `golang/goroutine/.../separate_channel` | `undefined: Result` | 누락된 `Result` 타입 정의 추가 |
| `go-unit-test/mockery/message` | 손작성 mock이 인터페이스 미구현 (`bool` vs `error`) | mock/테스트를 `error` 반환으로 수정 |
| `database/mongo/test/memongo` | `memongo.Options.ShouldUseReplica` 필드 제거됨 | 해당 필드 사용 제거 (기본값 false, 동작 동일) |

## Test plan
- [x] `go build ./...` 통과 (exit 0)
- [x] 전체 테스트 컴파일 통과 (`go test -run xxx -vet=off ./...`)
- [ ] 일부 통합 테스트(mongo/redis 등)는 Docker/외부 의존성 필요 — 별도