### PR TITLE
feat: SNS 로그인 콜백 경로 버전별 분리

### DIFF
--- a/web/sns-login-jwt/backend/.env.example
+++ b/web/sns-login-jwt/backend/.env.example
@@ -1,5 +1,5 @@
 GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
-GOOGLE_REDIRECT_URL=http://localhost:8080/api/auth/google/callback
+GOOGLE_REDIRECT_URL=http://localhost:3000/auth/jwt/callback
 JWT_SECRET=your-jwt-secret-key
-FRONTEND_URL=http://localhost:5173
+FRONTEND_URL=http://localhost:3000

--- a/web/sns-login-jwt/backend/config/config.go
+++ b/web/sns-login-jwt/backend/config/config.go
@@ -21,7 +21,7 @@ func Load() *Config {
 	return &Config{
 		GoogleClientID:     getEnv("GOOGLE_CLIENT_ID", ""),
 		GoogleClientSecret: getEnv("GOOGLE_CLIENT_SECRET", ""),
-		GoogleRedirectURL:  getEnv("GOOGLE_REDIRECT_URL", "http://localhost:3000/auth/callback"),
+		GoogleRedirectURL:  getEnv("GOOGLE_REDIRECT_URL", "http://localhost:3000/auth/jwt/callback"),
 		JWTSecret:          getEnv("JWT_SECRET", "dev-only-change-me"),
 		FrontendURL:        getEnv("FRONTEND_URL", "http://localhost:3000"),
 		ServerPort:         getEnv("SERVER_PORT", "8080"),

--- a/web/sns-login-jwt/docker-compose.yml
+++ b/web/sns-login-jwt/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     environment:
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
       - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
-      - GOOGLE_REDIRECT_URL=http://localhost:3000/auth/callback
+      - GOOGLE_REDIRECT_URL=http://localhost:3000/auth/jwt/callback
       - JWT_SECRET=${JWT_SECRET:-dev-only-change-me}
       - FRONTEND_URL=http://localhost:3000
       - SERVER_PORT=8080

--- a/web/sns-login-jwt/frontend/src/App.tsx
+++ b/web/sns-login-jwt/frontend/src/App.tsx
@@ -26,7 +26,7 @@ function App() {
           }
         />
         <Route
-          path="/auth/callback"
+          path="/auth/jwt/callback"
           element={<OAuthCallback onLogin={login} />}
         />
         <Route

--- a/web/sns-login-session/backend/.env.example
+++ b/web/sns-login-session/backend/.env.example
@@ -1,4 +1,4 @@
 GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
-GOOGLE_REDIRECT_URL=http://localhost:8080/api/auth/google/callback
+GOOGLE_REDIRECT_URL=http://localhost:8080/api/auth/session/callback
 FRONTEND_URL=http://localhost:3000

--- a/web/sns-login-session/backend/config/config.go
+++ b/web/sns-login-session/backend/config/config.go
@@ -20,7 +20,7 @@ func Load() *Config {
 	return &Config{
 		GoogleClientID:     getEnv("GOOGLE_CLIENT_ID", ""),
 		GoogleClientSecret: getEnv("GOOGLE_CLIENT_SECRET", ""),
-		GoogleRedirectURL:  getEnv("GOOGLE_REDIRECT_URL", "http://localhost:8080/api/auth/google/callback"),
+		GoogleRedirectURL:  getEnv("GOOGLE_REDIRECT_URL", "http://localhost:8080/api/auth/session/callback"),
 		FrontendURL:        getEnv("FRONTEND_URL", "http://localhost:3000"),
 		ServerPort:         getEnv("SERVER_PORT", "8080"),
 	}

--- a/web/sns-login-session/backend/handler/auth_handler.go
+++ b/web/sns-login-session/backend/handler/auth_handler.go
@@ -27,9 +27,9 @@ func (h *AuthHandler) GetAuthURL(c echo.Context) error {
 	return c.JSON(http.StatusOK, map[string]string{"url": url})
 }
 
-// GET /api/auth/:provider/callback — Google이 직접 redirect (redirect_uri = 백엔드)
+// GET /api/auth/session/callback — Google이 직접 redirect (redirect_uri = 백엔드)
 func (h *AuthHandler) HandleCallback(c echo.Context) error {
-	providerName := c.Param("provider")
+	const providerName = "google" // 세션 버전은 Google 전용 서버 redirect 콜백
 	code := c.QueryParam("code")
 	state := c.QueryParam("state")
 	if code == "" {

--- a/web/sns-login-session/backend/main.go
+++ b/web/sns-login-session/backend/main.go
@@ -69,7 +69,8 @@ func main() {
 
 	auth := api.Group("/auth")
 	auth.GET("/:provider/url", authHandler.GetAuthURL)
-	auth.GET("/:provider/callback", authHandler.HandleCallback)
+	// 세션 버전은 Google이 백엔드로 직접 redirect하는 전용 콜백 (JWT 버전과 구분되도록 /session 경로 사용)
+	auth.GET("/session/callback", authHandler.HandleCallback)
 	auth.POST("/logout", authHandler.Logout)
 
 	user := api.Group("/user", customMiddleware.SessionAuth(sessionService))

--- a/web/sns-login-session/docker-compose.yml
+++ b/web/sns-login-session/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     environment:
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
       - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
-      - GOOGLE_REDIRECT_URL=http://localhost:8080/api/auth/google/callback
+      - GOOGLE_REDIRECT_URL=http://localhost:8080/api/auth/session/callback
       - FRONTEND_URL=http://localhost:3000
       - SERVER_PORT=8080
     volumes:


### PR DESCRIPTION
## Summary
같은 OAuth 클라이언트를 공유하는 JWT/세션 두 버전의 redirect URI가 헷갈리지 않도록 경로에 버전을 명시한다.

- **JWT** (`web/sns-login-jwt`): Google이 redirect하는 **프론트 콜백 경로**를 `/auth/callback` → `/auth/jwt/callback` 으로 변경
  - `frontend/src/App.tsx`(라우트), `backend/config/config.go`(기본값), `docker-compose.yml`, `backend/.env.example`
  - `.env.example`의 잘못된 값 교정: redirect `8080` → 프론트 `3000`, `FRONTEND_URL` `5173` → `3000`
- **세션** (`web/sns-login-session`): Google이 직접 redirect하는 **백엔드 콜백 경로**를 `/api/auth/google/callback` → `/api/auth/session/callback` 으로 변경
  - `backend/main.go`(라우트 `/:provider/callback` → `/session/callback`), `backend/handler/auth_handler.go`(provider `"google"` 고정), `config.go`, `docker-compose.yml`, `.env.example`
- 내부 FE→BE 교환 API(`/api/auth/:provider/callback`)와 JWT의 `:provider` 패턴은 유지

> 관련 블로그 가이드: `kenshin579/blog-v2.advenoh.pe.kr#528`

## Test plan
- [x] `go build ./...` (양쪽 backend)
- [x] `go vet ./...` (양쪽 backend)
- [ ] Google Console에 두 redirect URI 등록 후 JWT/세션 로그인 E2E
- [ ] redirect_uri exact-match (포트·경로·끝 슬래시) 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)