### PR TITLE
feat: sns-login 환경변수 설정 및 Makefile 추가

### DIFF
--- a/web/sns-login-jwt/.gitignore
+++ b/web/sns-login-jwt/.gitignore
@@ -1,0 +1,7 @@
+# 런타임 산출물
+backend/data/
+backend/bin/
+backend/.env
+frontend/dist/
+frontend/node_modules/
+frontend/.env

--- a/web/sns-login-jwt/Makefile
+++ b/web/sns-login-jwt/Makefile
@@ -1,0 +1,31 @@
+.DEFAULT_GOAL := help
+.PHONY: help run-be run-fe run-all up down logs
+
+# Google OAuth 자격 증명은 ~/.zshrc 의 WEB_SNS_LOGIN_GOOGLE_CLIENT_ID/SECRET 를 우선 사용하며,
+# 없으면 backend/.env 의 GOOGLE_CLIENT_ID/SECRET 로 fallback 한다.
+
+help: ## 사용 가능한 명령어 목록
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-8s\033[0m %s\n", $$1, $$2}'
+
+run-be: ## Backend 실행 (Go, 포트 8080)
+	cd backend && mkdir -p data && go run .
+
+run-fe: ## Frontend 실행 (Vite, 포트 3000)
+	cd frontend && npm run dev
+
+run-all: ## Backend + Frontend 동시 실행 (Ctrl+C 로 함께 종료)
+	@echo "▶ backend(:8080) + frontend(:3000) 실행 — Ctrl+C 로 종료"
+	@trap 'kill 0' INT TERM EXIT; \
+		( cd backend && mkdir -p data && go run . ) & \
+		( cd frontend && npm run dev ) & \
+		wait
+
+up: ## docker compose 전체 스택 실행 (frontend :3000, backend :8080)
+	docker compose up --build
+
+down: ## docker compose 종료
+	docker compose down
+
+logs: ## docker compose 로그 확인
+	docker compose logs -f

--- a/web/sns-login-jwt/backend/.env.example
+++ b/web/sns-login-jwt/backend/.env.example
@@ -1,3 +1,5 @@
+# Google OAuth 자격 증명.
+# WEB_SNS_LOGIN_GOOGLE_CLIENT_ID/SECRET 환경 변수가 있으면 그 값을 우선 사용한다.
 GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 GOOGLE_REDIRECT_URL=http://localhost:3000/auth/jwt/callback

--- a/web/sns-login-jwt/backend/config/config.go
+++ b/web/sns-login-jwt/backend/config/config.go
@@ -19,8 +19,8 @@ func Load() *Config {
 	godotenv.Load() // .env 파일이 없어도 무시
 
 	return &Config{
-		GoogleClientID:     getEnv("GOOGLE_CLIENT_ID", ""),
-		GoogleClientSecret: getEnv("GOOGLE_CLIENT_SECRET", ""),
+		GoogleClientID:     getEnvAny([]string{"WEB_SNS_LOGIN_GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_ID"}, ""),
+		GoogleClientSecret: getEnvAny([]string{"WEB_SNS_LOGIN_GOOGLE_CLIENT_SECRET", "GOOGLE_CLIENT_SECRET"}, ""),
 		GoogleRedirectURL:  getEnv("GOOGLE_REDIRECT_URL", "http://localhost:3000/auth/jwt/callback"),
 		JWTSecret:          getEnv("JWT_SECRET", "dev-only-change-me"),
 		FrontendURL:        getEnv("FRONTEND_URL", "http://localhost:3000"),
@@ -31,6 +31,16 @@ func Load() *Config {
 func getEnv(key, defaultVal string) string {
 	if val := os.Getenv(key); val != "" {
 		return val
+	}
+	return defaultVal
+}
+
+// getEnvAny는 keys를 순서대로 조회하여 처음으로 값이 있는 환경 변수를 반환한다.
+func getEnvAny(keys []string, defaultVal string) string {
+	for _, key := range keys {
+		if val := os.Getenv(key); val != "" {
+			return val
+		}
 	}
 	return defaultVal
 }

--- a/web/sns-login-jwt/docker-compose.yml
+++ b/web/sns-login-jwt/docker-compose.yml
@@ -4,8 +4,11 @@ services:
     ports:
       - "8080:8080"
     environment:
-      - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
-      - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
+      # WEB_SNS_LOGIN_* 가 있으면 우선, 없으면 GOOGLE_* 로 fallback (backend config 와 동일 우선순위)
+      - WEB_SNS_LOGIN_GOOGLE_CLIENT_ID=${WEB_SNS_LOGIN_GOOGLE_CLIENT_ID:-}
+      - WEB_SNS_LOGIN_GOOGLE_CLIENT_SECRET=${WEB_SNS_LOGIN_GOOGLE_CLIENT_SECRET:-}
+      - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID:-}
+      - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET:-}
       - GOOGLE_REDIRECT_URL=http://localhost:3000/auth/jwt/callback
       - JWT_SECRET=${JWT_SECRET:-dev-only-change-me}
       - FRONTEND_URL=http://localhost:3000

--- a/web/sns-login-jwt/frontend/vite.config.ts
+++ b/web/sns-login-jwt/frontend/vite.config.ts
@@ -4,7 +4,7 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 5173,
+    port: 3000,
     proxy: {
       '/api': {
         target: 'http://localhost:8080',

--- a/web/sns-login-session/.gitignore
+++ b/web/sns-login-session/.gitignore
@@ -1,0 +1,7 @@
+# 런타임 산출물
+backend/data/
+backend/bin/
+backend/.env
+frontend/dist/
+frontend/node_modules/
+frontend/.env

--- a/web/sns-login-session/Makefile
+++ b/web/sns-login-session/Makefile
@@ -1,0 +1,31 @@
+.DEFAULT_GOAL := help
+.PHONY: help run-be run-fe run-all up down logs
+
+# Google OAuth 자격 증명은 ~/.zshrc 의 WEB_SNS_LOGIN_GOOGLE_CLIENT_ID/SECRET 를 우선 사용하며,
+# 없으면 backend/.env 의 GOOGLE_CLIENT_ID/SECRET 로 fallback 한다.
+
+help: ## 사용 가능한 명령어 목록
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-8s\033[0m %s\n", $$1, $$2}'
+
+run-be: ## Backend 실행 (Go, 포트 8080)
+	cd backend && mkdir -p data && go run .
+
+run-fe: ## Frontend 실행 (Vite, 포트 3000)
+	cd frontend && npm run dev
+
+run-all: ## Backend + Frontend 동시 실행 (Ctrl+C 로 함께 종료)
+	@echo "▶ backend(:8080) + frontend(:3000) 실행 — Ctrl+C 로 종료"
+	@trap 'kill 0' INT TERM EXIT; \
+		( cd backend && mkdir -p data && go run . ) & \
+		( cd frontend && npm run dev ) & \
+		wait
+
+up: ## docker compose 전체 스택 실행 (frontend :3000, backend :8080)
+	docker compose up --build
+
+down: ## docker compose 종료
+	docker compose down
+
+logs: ## docker compose 로그 확인
+	docker compose logs -f

--- a/web/sns-login-session/backend/.env.example
+++ b/web/sns-login-session/backend/.env.example
@@ -1,3 +1,5 @@
+# Google OAuth 자격 증명.
+# WEB_SNS_LOGIN_GOOGLE_CLIENT_ID/SECRET 환경 변수가 있으면 그 값을 우선 사용한다.
 GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 GOOGLE_REDIRECT_URL=http://localhost:8080/api/auth/session/callback

--- a/web/sns-login-session/backend/config/config.go
+++ b/web/sns-login-session/backend/config/config.go
@@ -18,8 +18,8 @@ func Load() *Config {
 	godotenv.Load() // .env 파일이 없어도 무시
 
 	return &Config{
-		GoogleClientID:     getEnv("GOOGLE_CLIENT_ID", ""),
-		GoogleClientSecret: getEnv("GOOGLE_CLIENT_SECRET", ""),
+		GoogleClientID:     getEnvAny([]string{"WEB_SNS_LOGIN_GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_ID"}, ""),
+		GoogleClientSecret: getEnvAny([]string{"WEB_SNS_LOGIN_GOOGLE_CLIENT_SECRET", "GOOGLE_CLIENT_SECRET"}, ""),
 		GoogleRedirectURL:  getEnv("GOOGLE_REDIRECT_URL", "http://localhost:8080/api/auth/session/callback"),
 		FrontendURL:        getEnv("FRONTEND_URL", "http://localhost:3000"),
 		ServerPort:         getEnv("SERVER_PORT", "8080"),
@@ -29,6 +29,16 @@ func Load() *Config {
 func getEnv(key, defaultVal string) string {
 	if val := os.Getenv(key); val != "" {
 		return val
+	}
+	return defaultVal
+}
+
+// getEnvAny는 keys를 순서대로 조회하여 처음으로 값이 있는 환경 변수를 반환한다.
+func getEnvAny(keys []string, defaultVal string) string {
+	for _, key := range keys {
+		if val := os.Getenv(key); val != "" {
+			return val
+		}
 	}
 	return defaultVal
 }

--- a/web/sns-login-session/docker-compose.yml
+++ b/web/sns-login-session/docker-compose.yml
@@ -4,8 +4,11 @@ services:
     ports:
       - "8080:8080"
     environment:
-      - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
-      - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
+      # WEB_SNS_LOGIN_* 가 있으면 우선, 없으면 GOOGLE_* 로 fallback (backend config 와 동일 우선순위)
+      - WEB_SNS_LOGIN_GOOGLE_CLIENT_ID=${WEB_SNS_LOGIN_GOOGLE_CLIENT_ID:-}
+      - WEB_SNS_LOGIN_GOOGLE_CLIENT_SECRET=${WEB_SNS_LOGIN_GOOGLE_CLIENT_SECRET:-}
+      - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID:-}
+      - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET:-}
       - GOOGLE_REDIRECT_URL=http://localhost:8080/api/auth/session/callback
       - FRONTEND_URL=http://localhost:3000
       - SERVER_PORT=8080

--- a/web/sns-login-session/frontend/vite.config.ts
+++ b/web/sns-login-session/frontend/vite.config.ts
@@ -4,7 +4,7 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 5173,
+    port: 3000,
     proxy: {
       '/api': {
         target: 'http://localhost:8080',


### PR DESCRIPTION
## Summary
- `sns-login-jwt`, `sns-login-session` 양쪽 backend config가 `WEB_SNS_LOGIN_GOOGLE_CLIENT_ID/SECRET`를 우선 읽고, 없으면 기존 `GOOGLE_CLIENT_ID/SECRET`로 fallback (`getEnvAny` 헬퍼)
- `docker-compose.yml`에 `WEB_SNS_LOGIN_*` 환경변수 전달 추가 (`${VAR:-}`로 미설정 경고 제거)
- 각 프로젝트 루트에 `Makefile` 추가: `run-be` / `run-fe` / `run-all` / `up` / `down` / `logs`
- frontend vite dev 포트 `5173 → 3000` 변경 — Google OAuth redirect URI(`localhost:3000/auth/jwt/callback`) 및 backend `FRONTEND_URL` 기본값과 일치 (로컬 로그인 콜백 `ERR_CONNECTION_REFUSED` 해결)
- 런타임 산출물(`backend/data`, `backend/bin`, `frontend/dist`, `.env`) `.gitignore` 추가

## Test plan
- [ ] `make run-all`로 backend(:8080) + frontend(:3000) 기동 확인
- [ ] sns-login-jwt: `http://localhost:3000`에서 Google 로그인 → 콜백 정상 처리 확인
- [ ] sns-login-session: Google 로그인 → backend(:8080) 콜백 → frontend(:3000) 리디렉션 확인
- [ ] `go build ./...` / `go test ./...` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)