### PR TITLE
feat: go tool trace 시각화 예제 코드 추가/보강

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ terraform.tfstate.backup
 **/dist-ssr
 *.local
 .idea
+
+# go tool trace 출력물 (커밋 금지)
+golang/concurrency/trace/tmp/

--- a/golang/concurrency/patterns/worker_pool_test.go
+++ b/golang/concurrency/patterns/worker_pool_test.go
@@ -25,6 +25,12 @@ func TestWorkerPool(t *testing.T) {
 	jobs := make(chan Job, numJobs)
 	results := make(chan Result, numJobs)
 
+	// 실제 작업 단위. 예제라서 제곱 연산이지만, 실무에선 이 함수 안에
+	// HTTP 요청 / 이미지 리사이징 / 로그 파싱 같은 진짜 처리 로직이 들어간다.
+	process := func(input int) int {
+		return input * input
+	}
+
 	// Worker 시작
 	var wg sync.WaitGroup
 	for w := range numWorkers {
@@ -32,10 +38,9 @@ func TestWorkerPool(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for job := range jobs {
-				// 작업 처리: 제곱 계산
 				results <- Result{
 					JobID:  job.ID,
-					Output: job.Input * job.Input,
+					Output: process(job.Input), // ← Output은 "작업 함수가 만들어내는 값"
 				}
 				t.Logf("worker %d processed job %d", w, job.ID)
 			}

--- a/golang/concurrency/trace/basic_trace_test.go
+++ b/golang/concurrency/trace/basic_trace_test.go
@@ -10,11 +10,15 @@ import (
 )
 
 // TestBasicTrace_Start_Stop - trace.Start/Stop으로 기본 trace 수집
-// 수집된 trace 파일은 `go tool trace trace_basic.out` 으로 분석 가능
+// 수집된 trace 파일은 `go tool trace tmp/trace_basic.out` 으로 분석 가능
 func TestBasicTrace_Start_Stop(t *testing.T) {
-	f, err := os.CreateTemp(t.TempDir(), "trace_basic_*.out")
+	// tmp 폴더에 영속적으로 저장 (t.TempDir()과 달리 테스트 후에도 남아 go tool trace로 분석 가능)
+	err := os.MkdirAll("tmp", 0o755)
 	assert.NoError(t, err)
-	defer f.Close()
+
+	f, err := os.Create("tmp/trace_basic.out")
+	assert.NoError(t, err)
+	defer func() { _ = f.Close() }()
 
 	// trace 수집 시작
 	err = rttrace.Start(f)

--- a/golang/concurrency/trace/crawler_trace_test.go
+++ b/golang/concurrency/trace/crawler_trace_test.go
@@ -23,10 +23,13 @@ import (
 //  3. Worker 활용률: goroutine이 idle인 시간 비율
 //  4. Blocking 분석: channel 대기, HTTP 응답 대기 등
 func TestCrawler_Task_Region_계측(t *testing.T) {
-	// trace 수집 설정
-	f, err := os.CreateTemp(t.TempDir(), "trace_crawler_*.out")
+	// trace 수집 설정 (tmp 폴더에 영속 저장 → go tool trace tmp/trace_crawler.out)
+	err := os.MkdirAll("tmp", 0o755)
 	assert.NoError(t, err)
-	defer f.Close()
+
+	f, err := os.Create("tmp/trace_crawler.out")
+	assert.NoError(t, err)
+	defer func() { _ = f.Close() }()
 
 	err = rttrace.Start(f)
 	assert.NoError(t, err)

--- a/golang/concurrency/trace/flight_recorder_test.go
+++ b/golang/concurrency/trace/flight_recorder_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	rttrace "runtime/trace"
 	"sync"
 	"testing"
@@ -73,8 +74,16 @@ func TestFlightRecorder_HTTP서버_Latency_감지(t *testing.T) {
 			var buf bytes.Buffer
 			n, err := fr.WriteTo(&buf)
 			assert.NoError(t, err)
+
+			// 스냅샷을 파일로 저장 → go tool trace로 분석 가능
+			err = os.MkdirAll("tmp", 0o755)
+			assert.NoError(t, err)
+			fname := fmt.Sprintf("tmp/trace_flight_%d.out", i)
+			err = os.WriteFile(fname, buf.Bytes(), 0o644)
+			assert.NoError(t, err)
+
 			snapshots = append(snapshots, n)
-			t.Logf("  → 스냅샷 캡처! (크기: %d bytes, latency: %v)", n, elapsed)
+			t.Logf("  → 스냅샷 캡처! (%s, 크기: %d bytes, latency: %v)", fname, n, elapsed)
 		}
 	}
 

--- a/golang/concurrency/trace/pprof_trace_combo_test.go
+++ b/golang/concurrency/trace/pprof_trace_combo_test.go
@@ -24,15 +24,19 @@ import (
 //  2. trace로 해당 구간의 동시성/타이밍을 분석하여
 //  3. 최적화 타겟을 정확히 결정할 수 있다
 func TestPprof_Trace_동시수집(t *testing.T) {
-	// 1. trace 파일 생성
-	traceFile, err := os.CreateTemp(t.TempDir(), "trace_combo_*.out")
+	// tmp 폴더에 영속 저장 (go tool trace tmp/trace_combo.out / go tool pprof tmp/cpu_combo.prof)
+	err := os.MkdirAll("tmp", 0o755)
 	assert.NoError(t, err)
-	defer traceFile.Close()
+
+	// 1. trace 파일 생성
+	traceFile, err := os.Create("tmp/trace_combo.out")
+	assert.NoError(t, err)
+	defer func() { _ = traceFile.Close() }()
 
 	// 2. CPU 프로파일 파일 생성
-	cpuFile, err := os.CreateTemp(t.TempDir(), "cpu_combo_*.prof")
+	cpuFile, err := os.Create("tmp/cpu_combo.prof")
 	assert.NoError(t, err)
-	defer cpuFile.Close()
+	defer func() { _ = cpuFile.Close() }()
 
 	// 3. trace 수집 시작
 	err = rttrace.Start(traceFile)

--- a/golang/concurrency/trace/task_region_test.go
+++ b/golang/concurrency/trace/task_region_test.go
@@ -16,9 +16,12 @@ import (
 // Task는 여러 goroutine에 걸친 논리적 작업을 하나로 묶어준다.
 // go tool trace에서 Task별 latency 히스토그램을 확인할 수 있다.
 func TestTask_NewTask_End(t *testing.T) {
-	f, err := os.CreateTemp(t.TempDir(), "trace_task_*.out")
+	err := os.MkdirAll("tmp", 0o755)
 	assert.NoError(t, err)
-	defer f.Close()
+
+	f, err := os.Create("tmp/trace_task.out")
+	assert.NoError(t, err)
+	defer func() { _ = f.Close() }()
 
 	err = rttrace.Start(f)
 	assert.NoError(t, err)
@@ -54,9 +57,12 @@ func TestTask_NewTask_End(t *testing.T) {
 // TestRegion_WithRegion - trace.WithRegion으로 구간 측정
 // Region은 단일 goroutine 내에서 특정 구간의 시간을 측정한다.
 func TestRegion_WithRegion(t *testing.T) {
-	f, err := os.CreateTemp(t.TempDir(), "trace_region_*.out")
+	err := os.MkdirAll("tmp", 0o755)
 	assert.NoError(t, err)
-	defer f.Close()
+
+	f, err := os.Create("tmp/trace_region.out")
+	assert.NoError(t, err)
+	defer func() { _ = f.Close() }()
 
 	err = rttrace.Start(f)
 	assert.NoError(t, err)
@@ -88,9 +94,12 @@ func TestRegion_WithRegion(t *testing.T) {
 // TestRegion_StartRegion_End - StartRegion/End로 유연한 구간 측정
 // WithRegion과 달리 함수 클로저 바깥에서도 Region을 제어할 수 있다.
 func TestRegion_StartRegion_End(t *testing.T) {
-	f, err := os.CreateTemp(t.TempDir(), "trace_startregion_*.out")
+	err := os.MkdirAll("tmp", 0o755)
 	assert.NoError(t, err)
-	defer f.Close()
+
+	f, err := os.Create("tmp/trace_startregion.out")
+	assert.NoError(t, err)
+	defer func() { _ = f.Close() }()
 
 	err = rttrace.Start(f)
 	assert.NoError(t, err)
@@ -121,9 +130,12 @@ func TestRegion_StartRegion_End(t *testing.T) {
 // TestLog_이벤트_마킹 - trace.Log로 trace에 커스텀 이벤트 기록
 // Log는 trace 타임라인에 특정 시점의 상태를 기록하여 디버깅에 활용한다.
 func TestLog_이벤트_마킹(t *testing.T) {
-	f, err := os.CreateTemp(t.TempDir(), "trace_log_*.out")
+	err := os.MkdirAll("tmp", 0o755)
 	assert.NoError(t, err)
-	defer f.Close()
+
+	f, err := os.Create("tmp/trace_log.out")
+	assert.NoError(t, err)
+	defer func() { _ = f.Close() }()
 
 	err = rttrace.Start(f)
 	assert.NoError(t, err)


### PR DESCRIPTION
## Summary
- Golang Concurrency 11편(go tool trace 시각화) 블로그 글의 companion 예제 코드
- Task/Region/Log 계측, FlightRecorder, pprof+trace 조합, 동시성 크롤러 트레이싱 예제 정리/보강
- FlightRecorder 스냅샷을 파일로 저장하도록 보강 → `go tool trace`로 직접 분석 가능
- `trace/tmp/`(go tool trace 출력물) `.gitignore` 추가로 커밋 방지

## Test plan
- [x] `go test ./golang/concurrency/trace/... ./golang/concurrency/patterns/...` 통과
- [ ] 생성된 trace를 `go tool trace`로 열어 User-defined tasks/regions 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)