### PR TITLE
fix: 주문 성공률 패널 쿼리에 sum 집계 추가

### DIFF
--- a/monitoring/grafana-metrics/dashboard/go-app-dashboard.json
+++ b/monitoring/grafana-metrics/dashboard/go-app-dashboard.json
@@ -141,7 +141,7 @@
       },
       "targets": [
         {
-          "expr": "rate(orders_created_total{status=\"success\"}[5m]) / rate(orders_created_total[5m]) * 100",
+          "expr": "sum(rate(orders_created_total{status=\"success\"}[5m])) / sum(rate(orders_created_total[5m])) * 100",
           "legendFormat": "Success Rate",
           "refId": "A"
         }


### PR DESCRIPTION
## Summary

`monitoring/grafana-metrics`의 `go-app-dashboard.json` 중 **주문 성공률 (%)** 패널이 항상 100%를 표시하는 문제를 수정합니다.

```promql
# 수정 전 — 항상 100%
rate(orders_created_total{status="success"}[5m]) / rate(orders_created_total[5m]) * 100

# 수정 후
sum(rate(orders_created_total{status="success"}[5m])) / sum(rate(orders_created_total[5m])) * 100
```

## 원인

`orders_created_total`의 라벨은 `status` 하나뿐입니다. PromQL의 이항 연산은 기본적으로 양쪽 시계열의 라벨이 모두 같은 것끼리 짝을 짓기 때문에, 왼쪽의 `{status="success"}`가 오른쪽의 같은 `{status="success"}`와 매칭됩니다. 결국 자기 자신을 나눈 값(=1)이 되어 언제나 100%가 나왔습니다.

`sum()`으로 `status` 라벨을 걷어내면 분자는 성공 건수, 분모는 전체 건수가 되어 의도한 비율이 계산됩니다.

## 검증

로컬 스택(`docker compose up -d`)에서 주문 120건을 생성한 뒤 두 쿼리를 비교했습니다.

| 쿼리 | 결과 |
|------|------|
| 수정 전 | `{status="success"} = 100.00 %` |
| 수정 후 | `{} = 88.89 %` |

- 대시보드 JSON 파싱 정상 (패널 7개)
- Grafana 프로비저닝 후 `/api/dashboards/uid/go-app-red`에서 수정된 식 반영 확인

같은 파일의 **에러율 (%)** 패널은 이미 `sum()`을 쓰고 있어 영향이 없습니다.

## Test plan

- [x] `docker compose up -d` 후 주문 생성, 성공률 패널이 실제 비율(≈89%)을 표시하는지 확인
- [x] Grafana 대시보드 프로비저닝 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)