### PR TITLE
chore: Docker Redis 이미지를 7로 고정하고 비밀번호 인증 옵션 추가

### DIFF
--- a/cloud/docker/redis/Makefile
+++ b/cloud/docker/redis/Makefile
@@ -1,8 +1,11 @@
 REDIS_CONTAINER_NAME := go-redis
+REDIS_IMAGE := redis:7
+REDIS_PASSWORD ?= mypassword
 
 .PHONY: redis-create
 redis-create:
-	@docker run --name $(REDIS_CONTAINER_NAME) -d -p 6379:6379 redis
+	@docker run --name $(REDIS_CONTAINER_NAME) -d -p 6379:6379 \
+		$(REDIS_IMAGE) redis-server --requirepass $(REDIS_PASSWORD)
 
 .PHONY: redis-delete
 redis-delete:
@@ -10,3 +13,7 @@ redis-delete:
 	@docker rm $(REDIS_CONTAINER_NAME)
 
 redis-recreate: redis-delete redis-create
+
+.PHONY: redis-cli
+redis-cli:
+	@docker exec -it $(REDIS_CONTAINER_NAME) redis-cli -a $(REDIS_PASSWORD)

--- a/cloud/docker/redis/Makefile
+++ b/cloud/docker/redis/Makefile
@@ -1,11 +1,14 @@
 REDIS_CONTAINER_NAME := go-redis
 REDIS_IMAGE := redis:7
-REDIS_PASSWORD ?= mypassword
+
+# 비밀번호 인증이 필요하면 아래 주석을 해제한다.
+# 주석 상태에서도 `make redis-create REDIS_PASSWORD=xxx`로 일회성 지정이 가능하다.
+#REDIS_PASSWORD ?= mypassword
 
 .PHONY: redis-create
 redis-create:
 	@docker run --name $(REDIS_CONTAINER_NAME) -d -p 6379:6379 \
-		$(REDIS_IMAGE) redis-server --requirepass $(REDIS_PASSWORD)
+		$(REDIS_IMAGE) redis-server $(if $(REDIS_PASSWORD),--requirepass $(REDIS_PASSWORD))
 
 .PHONY: redis-delete
 redis-delete:
@@ -16,4 +19,4 @@ redis-recreate: redis-delete redis-create
 
 .PHONY: redis-cli
 redis-cli:
-	@docker exec -it $(REDIS_CONTAINER_NAME) redis-cli -a $(REDIS_PASSWORD)
+	@docker exec -it $(REDIS_CONTAINER_NAME) redis-cli $(if $(REDIS_PASSWORD),-a $(REDIS_PASSWORD))

--- a/database/redis/redis/redis_test.go
+++ b/database/redis/redis/redis_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/kenshin579/tutorials-go/database/redis/model"
@@ -24,10 +25,18 @@ func teardown() {
 	client.Close()
 }
 
+// newRedisClient는 로컬 Redis에 접속하는 클라이언트를 생성한다.
+// 비밀번호는 REDIS_PASSWORD 환경변수로 재정의할 수 있으며,
+// 기본값은 cloud/docker/redis/Makefile의 requirepass 값과 동일하다.
 func newRedisClient() *redis.Client {
+	password := os.Getenv("REDIS_PASSWORD")
+	if password == "" {
+		password = "mypassword"
+	}
+
 	client := redis.NewClient(&redis.Options{
 		Addr:     "localhost:6379",
-		Password: "",
+		Password: password,
 		DB:       0,
 	})
 	return client

--- a/database/redis/redis/redis_test.go
+++ b/database/redis/redis/redis_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/kenshin579/tutorials-go/database/redis/model"
@@ -25,18 +24,10 @@ func teardown() {
 	client.Close()
 }
 
-// newRedisClient는 로컬 Redis에 접속하는 클라이언트를 생성한다.
-// 비밀번호는 REDIS_PASSWORD 환경변수로 재정의할 수 있으며,
-// 기본값은 cloud/docker/redis/Makefile의 requirepass 값과 동일하다.
 func newRedisClient() *redis.Client {
-	password := os.Getenv("REDIS_PASSWORD")
-	if password == "" {
-		password = "mypassword"
-	}
-
 	client := redis.NewClient(&redis.Options{
 		Addr:     "localhost:6379",
-		Password: password,
+		Password: "",
 		DB:       0,
 	})
 	return client


### PR DESCRIPTION
## 배경

`cloud/docker/redis/Makefile`이 태그 없는 `redis` 이미지를 띄우고 있어 버전이 고정되어 있지 않았다. 버전을 7로 고정하고, 필요할 때 비밀번호 인증을 켤 수 있는 스위치를 넣는다.

## 변경 사항

`cloud/docker/redis/Makefile` 한 파일만 수정한다.

- `REDIS_IMAGE := redis:7`로 버전 고정
- `REDIS_PASSWORD`는 **주석 처리된 상태가 기본**. 인증이 필요할 때 주석을 해제한다
- `--requirepass` / `-a` 옵션을 `$(if ...)`로 감싸서, 변수가 비어 있으면 옵션 자체가 붙지 않는다
- 주석 상태에서도 `make redis-create REDIS_PASSWORD=xxx`로 일회성 지정 가능
- `redis-cli` 타깃 추가 (비밀번호 설정 여부에 따라 `-a` 자동 처리)

공식 `redis` 이미지는 `REDIS_PASSWORD` 환경변수를 지원하지 않아(Bitnami 이미지 규약) `redis-server`의 커맨드 인자로 전달한다.

기본값이 무인증이므로 `localhost:6379`에 인증 없이 접속하는 기존 예제들(`scheduler/asynq`, `scheduler/go-cron`, `scheduler/dcron`, `rate-limiting`, `database/redis/blackboard`)의 동작은 그대로 유지된다. 예제 코드는 수정하지 않았다.

## 테스트 계획

`make -n`으로 3가지 경우의 커맨드 확장을 확인했다.

- [x] 기본(주석 상태) → `redis-server` (옵션 없음), `redis-cli` (옵션 없음)
- [x] `make redis-create REDIS_PASSWORD=secret1234` → `redis-server --requirepass secret1234`, `redis-cli -a secret1234`
- [x] 주석 해제 상태 → `redis-server --requirepass mypassword`, `redis-cli -a mypassword`
- [ ] `make redis-create` 후 `docker exec go-redis redis-server --version` → 7.x 확인
- [ ] 주석 해제 후 `make redis-recreate` → `docker exec -it go-redis redis-cli`가 `NOAUTH`, `make redis-cli`는 `PING` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)
