### PR TITLE
fix: Redis 이미지 태그 고정을 제거해 컨테이너 기동 실패 해결

### DIFF
--- a/cloud/docker/redis/Makefile
+++ b/cloud/docker/redis/Makefile
@@ -1,5 +1,4 @@
 REDIS_CONTAINER_NAME := go-redis
-REDIS_IMAGE := redis:7
 
 # 비밀번호 인증이 필요하면 아래 주석을 해제한다.
 # 주석 상태에서도 `make redis-create REDIS_PASSWORD=xxx`로 일회성 지정이 가능하다.
@@ -8,7 +7,7 @@ REDIS_IMAGE := redis:7
 .PHONY: redis-create
 redis-create:
 	@docker run --name $(REDIS_CONTAINER_NAME) -d -p 6379:6379 \
-		$(REDIS_IMAGE) redis-server $(if $(REDIS_PASSWORD),--requirepass $(REDIS_PASSWORD))
+		redis redis-server $(if $(REDIS_PASSWORD),--requirepass $(REDIS_PASSWORD))
 
 .PHONY: redis-delete
 redis-delete:


### PR DESCRIPTION
## 배경

직전 PR #724 에서 `REDIS_IMAGE := redis:7`로 태그를 고정한 뒤, `make redis-create`가 컨테이너 기동에 실패했다.

```
exec /usr/local/bin/docker-entrypoint.sh: exec format error
```

### 원인

Makefile 로직 문제가 아니라 **로컬 Docker 이미지 스토어 문제**다. 조사 과정은 다음과 같다.

1. `/bin/sh`조차 같은 에러로 실패. 호스트·이미지 모두 arm64로 아키텍처는 일치.
2. 이미지에서 파일을 추출해 보니 `usr/bin/{dash,bash,ls,cat}`이 전부 **0바이트**. 반면 `redis-server`(16MB)는 정상 aarch64 ELF → 데비안 베이스 레이어만 비어 있음.
3. 베이스 이미지 `debian:bookworm-slim` arm64 단독 실행도 동일하게 실패. `alpine:3`, `debian:12`, `redis:8`, `redis:7-alpine`은 정상.
4. `docker image ls --tree`에서 레이어 blob 부재 확인.

```
debian:bookworm-slim   DISK 110MB   CONTENT 2.36MB
└─ linux/arm64/v8      DISK 108MB   CONTENT 1.51kB   ← manifest+config만 존재
debian:12
└─ linux/arm64/v8      DISK 204MB   CONTENT 48.4MB   ← 정상
```

`docker save --platform linux/arm64 debian:bookworm-slim`도 `does not provide the specified platform`으로 거부된다. 0바이트 파일을 exec하면 커널이 포맷을 판별하지 못해 `ENOEXEC`, 즉 `exec format error`가 발생한다.

태그 없는 `redis`(latest, Redis 8)는 bookworm-slim을 쓰지 않아 영향을 받지 않는다. 태그 고정 전 동작으로 되돌린다.

## 변경 사항

- `REDIS_IMAGE := redis:7` 변수 제거, `docker run`이 태그 없는 `redis`를 쓰도록 환원

## 남은 이슈 (이 PR 범위 밖)

- 로컬 이미지 스토어 손상은 그대로다. `docker rmi` 후 재pull을 반복해도 레이어를 실제로 내려받지 않는다. Docker Desktop 재시작 또는 Purge data가 필요하다.
- Redis 7 버전이 꼭 필요하면 `redis:7-alpine`은 정상 동작한다(v7.4.10 확인).

## 테스트 계획

- [x] `make redis-create` → 컨테이너 기동 성공 (`Up`)
- [x] `docker exec go-redis redis-cli PING` → `PONG` (Redis v8.10.0)
- [ ] `make redis-delete`, `make redis-recreate`, `make redis-cli` 동작 확인
- [ ] `REDIS_PASSWORD=xxx make redis-create`로 인증 모드 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)