### PR TITLE
feat: singleflight로 중복 호출을 합치는 예제 추가

### DIFF
--- a/golang/singleflight/README.md
+++ b/golang/singleflight/README.md
@@ -76,6 +76,158 @@ go test -race -v ./golang/singleflight
 | `TestUserLoaderDoesNotCacheCompletedResult` | 완료된 결과는 보관하지 않는다 |
 | `TestUserLoaderSharesErrorWithConcurrentCallers` | 조회 오류도 동시 호출자에게 공유한다 |
 
+## 테스트 흐름
+
+### 테스트가 동시성을 만드는 방법
+
+`go test`는 goroutine이 실제로 겹쳐서 실행되는 시점을 보장하지 않는다. "동시에 요청이
+몰린 상황"을 매번 똑같이 재현하려고 테스트는 채널 세 개로 타이밍을 직접 제어한다.
+
+| 채널 | 방향 | 역할 |
+| --- | --- | --- |
+| `start` | 테스트 → goroutine | `close`로 모든 요청을 같은 시점에 출발시킨다 |
+| `started` | fetch → 테스트 | 데이터 소스 호출이 실제로 시작됐음을 테스트에 알린다 |
+| `release` | 테스트 → fetch | `close` 전까지 fetch를 붙잡아 느린 조회를 재현한다 |
+
+`close`를 쓰는 이유는 값 송신과 달리 대기 중인 goroutine을 한 번에 모두 깨우기
+때문이다. 값을 열 번 보내는 대신 채널을 한 번 닫으면 broadcast가 된다.
+
+`started` 신호를 몇 번 받는지가 곧 데이터 소스가 몇 번 호출됐는지를 뜻하므로,
+테스트는 이 신호로 중복 제거 여부를 판별한다.
+
+### 1. 적용 전에는 요청 수만큼 조회한다
+
+`TestWithoutSingleflightCallsDataSourceForEveryRequest`는 `UserLoader`를 거치지 않고
+`fetch`를 직접 호출한다. 비교 기준이 되는 "적용 전" 상태다.
+
+```mermaid
+sequenceDiagram
+    participant T as 테스트 본체
+    participant G as goroutine 10개
+    participant F as fetch (직접 호출)
+
+    T->>G: goroutine 10개 시작
+    G->>F: fetch("user-1") 각자 호출
+    Note over F: calls 10 증가<br/>10개 모두 release 채널에서 대기
+    F-->>T: started 신호 10개
+    Note over T: 신호 10개 = 10개가 동시에 fetch 안에 있다
+    T->>F: close(release)
+    F-->>G: 10개 각각 결과 반환
+    Note over T: calls == 10
+```
+
+### 2. 같은 key의 동시 조회는 한 번만 실행한다
+
+`TestUserLoaderCombinesConcurrentCallsForSameKey`는 같은 흐름을 `UserLoader`를 통해
+실행한다. 먼저 도착한 goroutine(리더)만 `fetch`에 진입하고 나머지는 그 호출에 합류한다.
+
+```mermaid
+sequenceDiagram
+    participant T as 테스트 본체
+    participant L as 리더 goroutine
+    participant D as 중복 goroutine 9개
+    participant SF as singleflight.Group
+    participant F as fetch
+
+    T->>T: close(start) — 10개 동시 출발
+    L->>SF: Do("user-1")
+    SF->>F: fetch 실행 (리더 1개만)
+    F-->>T: started 신호 1개
+    Note over F: release 채널에서 대기
+    D->>SF: Do("user-1") 9개 도착
+    Note over D,SF: 새 실행을 시작하지 않고 진행 중인 호출에 합류
+    T->>T: waitForDuplicates — 20ms 동안 결과가<br/>오지 않아야 통과 (합류 시간 확보)
+    T->>F: close(release)
+    F-->>SF: User{ID: "user-1"}
+    SF-->>L: 결과, shared=true
+    SF-->>D: 같은 결과, shared=true
+    Note over T: calls == 1
+```
+
+`waitForDuplicates`는 두 가지 역할을 한다. 중복 goroutine 9개가 `Group.Do`까지
+도달할 시간을 벌어 주고, 그 사이에 결과가 먼저 도착하면 fetch가 예상과 달리 이미
+끝났다는 뜻이므로 테스트를 실패시킨다.
+
+### 3. 다른 key는 각각 실행한다
+
+`TestUserLoaderRunsDifferentKeysIndependently`에서는 `started`가 `chan string`이라
+어떤 key의 조회가 시작됐는지까지 확인할 수 있다.
+
+```mermaid
+sequenceDiagram
+    participant T as 테스트 본체
+    participant G1 as goroutine user-1
+    participant G2 as goroutine user-2
+    participant SF as singleflight.Group
+    participant F as fetch
+
+    G1->>SF: Do("user-1")
+    SF->>F: fetch("user-1")
+    F-->>T: started 신호 "user-1"
+    G2->>SF: Do("user-2")
+    SF->>F: fetch("user-2") 별도 실행
+    F-->>T: started 신호 "user-2"
+    Note over T: 두 ID를 모두 받음<br/>= 서로 막지 않았다는 증거
+    T->>F: close(release)
+    SF-->>G1: 결과, shared=false
+    SF-->>G2: 결과, shared=false
+    Note over T: calls == 2
+```
+
+각 key를 요청한 호출자가 하나뿐이므로 `shared`는 둘 다 `false`다.
+
+### 4. 완료된 결과는 보관하지 않는다
+
+`TestUserLoaderDoesNotCacheCompletedResult`는 유일하게 동시성이 없는 테스트다.
+같은 key를 순차로 두 번 조회한다.
+
+```mermaid
+sequenceDiagram
+    participant T as 테스트 본체
+    participant SF as singleflight.Group
+    participant F as fetch
+
+    T->>SF: Load("user-1") 1회차
+    SF->>F: fetch 실행
+    F-->>SF: User{ID: "user-1"}
+    SF-->>T: 결과, shared=false
+    Note over SF: 호출이 끝나면 key 정보를 버린다
+
+    T->>SF: Load("user-1") 2회차
+    SF->>F: fetch 재실행 (보관된 결과 없음)
+    F-->>SF: User{ID: "user-1"}
+    SF-->>T: 결과, shared=false
+    Note over T: calls == 2 — 캐시가 아니다
+```
+
+### 5. 조회 오류도 동시 호출자에게 공유한다
+
+`TestUserLoaderSharesErrorWithConcurrentCallers`는 2번과 구조가 같고 `fetch`의
+반환값만 오류다.
+
+```mermaid
+sequenceDiagram
+    participant T as 테스트 본체
+    participant L as 리더 goroutine
+    participant D as 중복 goroutine 9개
+    participant SF as singleflight.Group
+    participant F as fetch
+
+    T->>T: close(start) — 10개 동시 출발
+    L->>SF: Do("user-1")
+    SF->>F: fetch 실행 (리더 1개만)
+    F-->>T: started 신호 1개
+    D->>SF: Do("user-1") 9개 합류
+    T->>F: close(release)
+    F-->>SF: error "data source unavailable"
+    SF-->>L: 같은 error, shared=true
+    SF-->>D: 같은 error, shared=true
+    Note over T: calls == 1 — 오류도 그대로 공유된다
+```
+
+일시적인 오류 하나가 대기 중인 요청 전부에 전달된다는 뜻이기도 하다. 재시도 정책을
+설계할 때 고려해야 할 동작이다.
+
 ## 캐시와의 차이
 
 `singleflight`는 캐시가 아니다. 실행 중인 호출만 합치므로 첫 호출이 끝난 뒤 같은

--- a/golang/singleflight/README.md
+++ b/golang/singleflight/README.md
@@ -1,0 +1,104 @@
+# singleflight로 중복 호출 합치기
+
+`golang.org/x/sync/singleflight`는 같은 key로 동시에 실행되는 함수 호출을 하나로
+합친다. 캐시가 비어 있을 때 요청이 한꺼번에 몰려 DB나 외부 API가 반복 호출되는
+cache stampede 문제를 완화할 때 유용하다.
+
+```text
+적용 전
+요청 10개 ──> DB/API 호출 10번
+
+적용 후
+요청 10개 ──> singleflight.Group ──> DB/API 호출 1번
+                         └──────────> 결과 또는 오류 공유
+```
+
+## 핵심 코드
+
+`UserLoader`는 사용자 ID를 key로 사용한다. `user-1`에 대한 조회가 진행 중일 때
+같은 ID로 들어온 호출은 새 조회를 시작하지 않고 먼저 시작된 호출의 반환을 기다린다.
+
+```go
+value, err, shared := group.Do(userID, func() (any, error) {
+	return fetch(userID)
+})
+```
+
+- `value`: 조회 함수가 반환한 값
+- `err`: 조회 함수가 반환한 오류
+- `shared`: 결과가 둘 이상의 호출자에게 전달되었는지 여부
+
+`user-1`과 `user-2`처럼 key가 다르면 두 조회는 서로 막지 않고 독립적으로 실행된다.
+
+## 동시 요청 흐름
+
+```mermaid
+sequenceDiagram
+    participant R1 as 요청 1
+    participant R2 as 요청 2
+    participant R3 as 요청 3
+    participant SF as singleflight.Group
+    participant DS as DB/API
+
+    R1->>SF: Do("user-1")
+    SF->>DS: fetch("user-1") 실행
+    R2->>SF: Do("user-1")
+    Note over R2,SF: 같은 key의 실행이 끝날 때까지 대기
+    R3->>SF: Do("user-2")
+    SF->>DS: fetch("user-2") 별도 실행
+
+    DS-->>SF: user-2 결과
+    SF-->>R3: 결과 반환 (shared=false)
+    DS-->>SF: user-1 결과
+    SF-->>R1: 같은 결과 반환 (shared=true)
+    SF-->>R2: 같은 결과 반환 (shared=true)
+```
+
+`요청 1`과 `요청 2`는 key가 같으므로 `fetch("user-1")`을 한 번만 실행한다.
+`요청 3`은 key가 다르므로 앞선 요청과 독립적으로 실행된다. `shared`는 결과가 둘
+이상의 호출자에게 전달되었는지를 나타내므로 최초 호출자인 `요청 1`에도 `true`가
+반환된다.
+
+## 테스트 실행
+
+```bash
+go test -race -v ./golang/singleflight
+```
+
+테스트에서는 채널로 느린 데이터 소스를 재현하고 `atomic.Int64`로 실제 호출 횟수를
+측정한다.
+
+| 테스트 | 확인하는 동작 |
+| --- | --- |
+| `TestWithoutSingleflightCallsDataSourceForEveryRequest` | 적용 전에는 요청 수만큼 조회한다 |
+| `TestUserLoaderCombinesConcurrentCallsForSameKey` | 같은 key의 동시 조회는 한 번만 실행한다 |
+| `TestUserLoaderRunsDifferentKeysIndependently` | 다른 key는 각각 실행한다 |
+| `TestUserLoaderDoesNotCacheCompletedResult` | 완료된 결과는 보관하지 않는다 |
+| `TestUserLoaderSharesErrorWithConcurrentCallers` | 조회 오류도 동시 호출자에게 공유한다 |
+
+## 캐시와의 차이
+
+`singleflight`는 캐시가 아니다. 실행 중인 호출만 합치므로 첫 호출이 끝난 뒤 같은
+key를 다시 조회하면 함수가 다시 실행된다. 실무에서는 일반적으로 다음 순서로 캐시와
+함께 사용한다.
+
+1. 캐시에서 값을 조회한다.
+2. cache miss이면 `Group.Do`에 진입한다.
+3. 함수 안에서 캐시를 다시 확인한다.
+4. 여전히 값이 없으면 원본 데이터를 조회하고 캐시에 저장한다.
+
+함수 안에서 캐시를 다시 확인하는 이유는 `Group.Do`에 진입하기 직전에 다른 요청이
+캐시를 채웠을 수 있기 때문이다.
+
+## 사용할 때 주의할 점
+
+- 중복 제거 범위는 하나의 `Group`, 즉 일반적으로 하나의 프로세스 내부다. 여러 서버
+  인스턴스 전체의 호출을 하나로 합치지는 않는다.
+- key에는 결과에 영향을 주는 조건을 모두 포함해야 한다. 예를 들어 사용자 ID뿐 아니라
+  언어에 따라 결과가 달라진다면 `userID + locale`을 key로 사용해야 한다.
+- 값뿐 아니라 오류도 공유된다. 일시적인 오류가 동시에 대기 중인 모든 요청에 전달될 수
+  있다.
+- `Do`는 함수가 끝날 때까지 대기한다. 호출자별 취소나 타임아웃을 선택적으로 처리해야
+  한다면 `DoChan`과 `select` 사용을 검토한다.
+- 한 호출자의 대기가 취소되더라도 이미 실행 중인 함수가 자동으로 취소되는 것은 아니다.
+  내부 작업의 수명과 `context.Context` 정책을 별도로 설계해야 한다.

--- a/golang/singleflight/README.md
+++ b/golang/singleflight/README.md
@@ -218,6 +218,7 @@ sequenceDiagram
     SF->>F: fetch 실행 (리더 1개만)
     F-->>T: started 신호 1개
     D->>SF: Do("user-1") 9개 합류
+    T->>T: waitForDuplicates — 20ms 동안 결과가<br/>오지 않아야 통과 (합류 시간 확보)
     T->>F: close(release)
     F-->>SF: error "data source unavailable"
     SF-->>L: 같은 error, shared=true

--- a/golang/singleflight/loader.go
+++ b/golang/singleflight/loader.go
@@ -1,0 +1,54 @@
+// Package singleflight provides an example of suppressing duplicate function
+// calls with golang.org/x/sync/singleflight.
+package singleflight
+
+import (
+	"fmt"
+
+	"golang.org/x/sync/singleflight"
+)
+
+// User is the value returned by the example data source.
+type User struct {
+	ID   string
+	Name string
+}
+
+// FetchUserFunc represents a slow database or external API call.
+type FetchUserFunc func(userID string) (User, error)
+
+// UserLoader combines concurrent requests for the same user ID.
+//
+// UserLoader does not cache completed results. It only suppresses duplicate
+// calls while a call with the same key is still in flight.
+type UserLoader struct {
+	group singleflight.Group
+	fetch FetchUserFunc
+}
+
+// NewUserLoader creates a UserLoader backed by fetch.
+func NewUserLoader(fetch FetchUserFunc) *UserLoader {
+	return &UserLoader{fetch: fetch}
+}
+
+// Load returns a user and reports whether the result was shared by multiple
+// callers. Concurrent calls using different user IDs run independently.
+func (l *UserLoader) Load(userID string) (user User, shared bool, err error) {
+	if l.fetch == nil {
+		return User{}, false, fmt.Errorf("fetch user function is nil")
+	}
+
+	value, err, shared := l.group.Do(userID, func() (any, error) {
+		return l.fetch(userID)
+	})
+	if err != nil {
+		return User{}, shared, err
+	}
+
+	user, ok := value.(User)
+	if !ok {
+		return User{}, shared, fmt.Errorf("unexpected user result type %T", value)
+	}
+
+	return user, shared, nil
+}

--- a/golang/singleflight/loader_test.go
+++ b/golang/singleflight/loader_test.go
@@ -1,0 +1,240 @@
+package singleflight
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+const concurrentRequests = 10
+
+type loadResult struct {
+	user   User
+	shared bool
+	err    error
+}
+
+// TestWithoutSingleflightCallsDataSourceForEveryRequest는 중복 제거를 적용하지 않은
+// 상태에서 같은 사용자를 동시에 요청하면 데이터 소스도 요청 수만큼 호출됨을 확인한다.
+func TestWithoutSingleflightCallsDataSourceForEveryRequest(t *testing.T) {
+	var calls atomic.Int64
+	// started는 각 goroutine이 fetch에 진입했음을 테스트 본체에 알린다.
+	// 모든 진입 신호를 막힘없이 담을 수 있도록 요청 수만큼 버퍼를 둔다.
+	started := make(chan struct{}, concurrentRequests)
+	// fetch는 release가 닫힐 때까지 대기하므로 느린 데이터 소스처럼 동작한다.
+	release := make(chan struct{})
+
+	fetch := func(userID string) (User, error) {
+		calls.Add(1)
+		started <- struct{}{} // fetch 진입을 알린다. 값 자체에는 의미가 없다.
+		<-release             // close(release)가 호출될 때까지 조회 완료를 막는다.
+		return User{ID: userID, Name: "Gopher"}, nil
+	}
+
+	var wg sync.WaitGroup
+	for range concurrentRequests {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = fetch("user-1")
+		}()
+	}
+
+	// 모든 fetch가 동시에 실행 중인 상태가 될 때까지 진입 신호를 받는다.
+	for range concurrentRequests {
+		<-started
+	}
+	// 채널을 닫으면 release를 기다리는 모든 goroutine이 한꺼번에 깨어난다.
+	close(release)
+	wg.Wait()
+
+	if got := calls.Load(); got != concurrentRequests {
+		t.Fatalf("fetch call count = %d, want %d", got, concurrentRequests)
+	}
+}
+
+// TestUserLoaderCombinesConcurrentCallsForSameKey는 같은 key의 동시 요청이 하나의
+// 데이터 소스 호출로 합쳐지고 모든 호출자가 같은 결과를 공유하는지 확인한다.
+func TestUserLoaderCombinesConcurrentCallsForSameKey(t *testing.T) {
+	var calls atomic.Int64
+	// singleflight가 제대로 동작하면 started에는 신호가 하나만 들어온다.
+	started := make(chan struct{}, concurrentRequests)
+	// 최초 fetch를 멈춰 둔 사이 나머지 요청들이 같은 호출에 합류하게 한다.
+	release := make(chan struct{})
+
+	loader := NewUserLoader(func(userID string) (User, error) {
+		calls.Add(1)
+		started <- struct{}{} // 실제 데이터 소스 호출이 시작됐음을 알린다.
+		<-release
+		return User{ID: userID, Name: "Gopher"}, nil
+	})
+
+	// 반환 채널을 먼저 받고, 모든 요청 결과는 아래에서 차례로 수집한다.
+	results := startConcurrentLoads(loader, concurrentRequests, "user-1")
+	<-started // 최초 요청이 fetch 안에서 대기 중임을 확인한다.
+	waitForDuplicates(t, results)
+	// 최초 fetch를 완료시키면 같은 key로 대기하던 요청들도 같은 결과를 받는다.
+	close(release)
+
+	for range concurrentRequests {
+		result := <-results
+		if result.err != nil {
+			t.Fatalf("Load() error = %v", result.err)
+		}
+		if result.user.ID != "user-1" {
+			t.Errorf("Load() user ID = %q, want %q", result.user.ID, "user-1")
+		}
+		if !result.shared {
+			t.Error("Load() shared = false, want true")
+		}
+	}
+
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("fetch call count = %d, want 1", got)
+	}
+}
+
+// TestUserLoaderRunsDifferentKeysIndependently는 서로 다른 key의 요청이 하나로
+// 합쳐지지 않고 각각 독립적으로 데이터 소스를 호출하는지 확인한다.
+func TestUserLoaderRunsDifferentKeysIndependently(t *testing.T) {
+	var calls atomic.Int64
+	// 어떤 key의 fetch가 시작됐는지 확인하기 위해 사용자 ID를 전달한다.
+	started := make(chan string, 2)
+	// 두 key의 fetch가 모두 시작된 것을 확인한 뒤 함께 완료시킨다.
+	release := make(chan struct{})
+
+	loader := NewUserLoader(func(userID string) (User, error) {
+		calls.Add(1)
+		started <- userID
+		<-release
+		return User{ID: userID}, nil
+	})
+
+	// key별 결과 채널을 분리해 각 요청의 반환값을 확인한다.
+	result1 := make(chan loadResult, 1)
+	result2 := make(chan loadResult, 1)
+	go loadInto(loader, "user-1", result1)
+	go loadInto(loader, "user-2", result2)
+
+	// started에서 두 ID를 받았다는 것은 서로 다른 두 fetch가 실행됐다는 뜻이다.
+	seen := map[string]bool{<-started: true, <-started: true}
+	close(release)
+
+	for _, result := range []loadResult{<-result1, <-result2} {
+		if result.err != nil {
+			t.Fatalf("Load() error = %v", result.err)
+		}
+		if result.shared {
+			t.Error("Load() shared = true for a key requested only once")
+		}
+	}
+
+	if !seen["user-1"] || !seen["user-2"] {
+		t.Fatalf("started keys = %v, want user-1 and user-2", seen)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("fetch call count = %d, want 2", got)
+	}
+}
+
+// TestUserLoaderDoesNotCacheCompletedResult는 첫 호출이 끝난 뒤 같은 key를 다시
+// 요청하면 데이터 소스가 재실행되어 singleflight가 캐시가 아님을 확인한다.
+func TestUserLoaderDoesNotCacheCompletedResult(t *testing.T) {
+	var calls atomic.Int64
+	loader := NewUserLoader(func(userID string) (User, error) {
+		calls.Add(1)
+		return User{ID: userID}, nil
+	})
+
+	for range 2 {
+		_, shared, err := loader.Load("user-1")
+		if err != nil {
+			t.Fatalf("Load() error = %v", err)
+		}
+		if shared {
+			t.Error("sequential Load() shared = true, want false")
+		}
+	}
+
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("fetch call count = %d, want 2", got)
+	}
+}
+
+// TestUserLoaderSharesErrorWithConcurrentCallers는 데이터 소스에서 발생한 오류도
+// 같은 key를 기다리는 모든 동시 호출자에게 공유되는지 확인한다.
+func TestUserLoaderSharesErrorWithConcurrentCallers(t *testing.T) {
+	var calls atomic.Int64
+	// 정상 결과 테스트와 마찬가지로 최초 fetch를 멈춰 중복 요청이 합류하게 한다.
+	started := make(chan struct{}, concurrentRequests)
+	release := make(chan struct{})
+	wantErr := errors.New("data source unavailable")
+
+	loader := NewUserLoader(func(string) (User, error) {
+		calls.Add(1)
+		started <- struct{}{}
+		<-release
+		return User{}, wantErr
+	})
+
+	results := startConcurrentLoads(loader, concurrentRequests, "user-1")
+	<-started
+	waitForDuplicates(t, results)
+	close(release)
+
+	for range concurrentRequests {
+		result := <-results
+		if !errors.Is(result.err, wantErr) {
+			t.Errorf("Load() error = %v, want %v", result.err, wantErr)
+		}
+		if !result.shared {
+			t.Error("Load() shared = false, want true")
+		}
+	}
+
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("fetch call count = %d, want 1", got)
+	}
+}
+
+func startConcurrentLoads(loader *UserLoader, count int, userID string) <-chan loadResult {
+	// start는 모든 goroutine을 같은 시점에 출발시키는 시작 신호다.
+	// 각 goroutine은 채널이 닫히기 전까지 아래의 수신 연산에서 대기한다.
+	start := make(chan struct{})
+	// 호출자가 결과를 즉시 읽지 않아도 goroutine이 송신에서 막히지 않도록
+	// 요청 수만큼 버퍼를 둔다.
+	results := make(chan loadResult, count)
+
+	for range count {
+		go func() {
+			<-start // close(start)가 모든 goroutine을 동시에 깨운다.
+			loadInto(loader, userID, results)
+		}()
+	}
+
+	// 값을 여러 번 보내는 대신 채널을 한 번 닫아 모든 대기자를 출발시킨다.
+	close(start)
+	return results
+}
+
+func loadInto(loader *UserLoader, userID string, results chan<- loadResult) {
+	user, shared, err := loader.Load(userID)
+	// 송신 전용 채널을 사용해 이 함수가 results를 수신하지 않음을 표현한다.
+	results <- loadResult{user: user, shared: shared, err: err}
+}
+
+// The leader remains blocked while duplicate goroutines enter Group.Do. The
+// timeout also makes a scheduler failure explicit instead of hanging the test.
+func waitForDuplicates(t *testing.T, results <-chan loadResult) {
+	t.Helper()
+
+	select {
+	// release가 닫히기 전에 결과가 오면 fetch가 예상과 달리 먼저 끝난 것이다.
+	case result := <-results:
+		t.Fatalf("Load() returned before data source was released: %+v", result)
+	// 짧게 기다리는 동안 중복 goroutine들이 Group.Do에 진입할 시간을 준다.
+	case <-time.After(20 * time.Millisecond):
+	}
+}


### PR DESCRIPTION
## 배경

캐시가 비어 있을 때 같은 key로 요청이 한꺼번에 몰리면 DB나 외부 API가 반복 호출되는 cache stampede가 발생한다. `golang.org/x/sync/singleflight`로 진행 중인 동일 key 호출을 하나로 합치는 예제를 추가했다.

## 변경 사항

- `golang/singleflight/loader.go` — 사용자 ID를 key로 사용하는 `UserLoader`. `Group.Do`로 중복 호출을 합치고 `shared` 여부를 함께 반환한다.
- `golang/singleflight/loader_test.go` — 채널로 느린 데이터 소스를 재현하고 `atomic.Int64`로 실제 호출 횟수를 측정하는 테스트 5개
  - 적용 전에는 요청 수만큼 조회한다
  - 같은 key의 동시 조회는 한 번만 실행한다
  - 다른 key는 각각 독립적으로 실행한다
  - 완료된 결과는 보관하지 않는다 (캐시가 아님)
  - 조회 오류도 동시 호출자에게 공유한다
- `golang/singleflight/README.md` — 동작 흐름(mermaid sequence diagram), 캐시와 함께 쓰는 패턴, 사용 시 주의점 정리

`golang.org/x/sync`는 이미 go.mod의 직접 의존성이라 모듈 변경은 없다.

## 테스트 계획

- [x] `go test -race ./golang/singleflight/...` 통과
- [x] `gofmt -l golang/singleflight/` 결과 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)